### PR TITLE
feat(compile): Add compile-mode support for external Java classes

### DIFF
--- a/core/src/main/java/com/elminster/jcp/compile/BytecodeGenerator.java
+++ b/core/src/main/java/com/elminster/jcp/compile/BytecodeGenerator.java
@@ -7,8 +7,10 @@ import com.elminster.jcp.ast.statement.declaration.FunctionDeclaration;
 import com.elminster.jcp.ast.statement.function.ParameterDef;
 import com.elminster.jcp.compile.context.CompileContext;
 import com.elminster.jcp.compile.declare.FunctionDeclarationCompiler;
+import com.elminster.jcp.compile.util.CompileModeClassConverter;
 import com.elminster.jcp.compile.util.TypeMapper;
 import com.elminster.jcp.eval.data.DataType;
+import com.elminster.jcp.module.base.BaseModuleRegister;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -70,6 +72,9 @@ public class BytecodeGenerator implements Opcodes {
         // Create root context for compilation
         rootContext = new CompileContext();
         rootContext.setClassName(className);
+
+        // Register module types for external class method calls
+        registerModuleTypes(rootContext);
 
         // Collect function declarations
         List<FunctionDeclaration> functions = new ArrayList<>();
@@ -250,6 +255,9 @@ public class BytecodeGenerator implements Opcodes {
         rootContext = new CompileContext();
         rootContext.setClassName(className);
 
+        // Register module types for external class method calls
+        registerModuleTypes(rootContext);
+
         // Collect function declarations and other statements
         List<FunctionDeclaration> functions = new ArrayList<>();
         List<Statement> evalStatements = new ArrayList<>();
@@ -326,5 +334,16 @@ public class BytecodeGenerator implements Opcodes {
 
         mv.visitMaxs(0, 0);
         mv.visitEnd();
+    }
+
+    /**
+     * Register built-in module types (Logger, Assertions, ValueBuffer) for compile-time use.
+     * This allows compiled JCP code to call methods on these external Java classes.
+     */
+    private void registerModuleTypes(CompileContext ctx) {
+        List<Class<?>> moduleClasses = BaseModuleRegister.classToRegister();
+        for (Class<?> clazz : moduleClasses) {
+            CompileModeClassConverter.registerClass(clazz, ctx, "base");
+        }
     }
 }

--- a/core/src/main/java/com/elminster/jcp/compile/function/FunCallCompiler.java
+++ b/core/src/main/java/com/elminster/jcp/compile/function/FunCallCompiler.java
@@ -13,6 +13,8 @@ import com.elminster.jcp.compile.factory.AstCompilerFactory;
 import com.elminster.jcp.compile.util.TypeMapper;
 import com.elminster.jcp.eval.data.DataType;
 import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.ExternalClassType;
+import com.elminster.jcp.eval.data.ExternalMethodDef;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -33,6 +35,16 @@ public class FunCallCompiler extends AbstractAstCompiler {
         FunctionCallExpression call = (FunctionCallExpression) astNode;
         String funcName = call.getId().getId();
         Expression[] args = call.getArguments();
+
+        // Check if this is an external class constructor call (TypeName.new)
+        if (funcName.endsWith(".new")) {
+            String typeName = funcName.substring(0, funcName.length() - 4);
+            DataType dataType = ctx.getDataType(typeName);
+            if (dataType instanceof ExternalClassType) {
+                compileExternalClassConstructor(mv, ctx, (ExternalClassType) dataType, args);
+                return;
+            }
+        }
 
         // Determine argument types for overload resolution
         DataType[] argTypes = new DataType[args.length];
@@ -70,5 +82,72 @@ public class FunCallCompiler extends AbstractAstCompiler {
             false
         );
         // Result (if any) is now on stack
+    }
+
+    /**
+     * Compile external class constructor call: TypeName.new(args)
+     */
+    private void compileExternalClassConstructor(MethodVisitor mv, CompileContext ctx,
+                                                  ExternalClassType extType, Expression[] args) {
+        // Determine argument types for overload resolution
+        DataType[] argTypes = new DataType[args.length];
+        for (int i = 0; i < args.length; i++) {
+            argTypes[i] = TypeMapper.getExpressionType(args[i], ctx);
+        }
+
+        // Look up constructor with overload resolution
+        ExternalMethodDef constructor = extType.getConstructor(argTypes);
+        if (constructor == null) {
+            throw new CompileException("Constructor for '" + extType.getName() +
+                "' with argument types " + Arrays.toString(argTypes) + " not found");
+        }
+
+        // Emit NEW instruction
+        mv.visitTypeInsn(Opcodes.NEW, extType.getInternalName());
+
+        // Emit DUP to have reference for constructor call
+        mv.visitInsn(Opcodes.DUP);
+
+        // Compile arguments (push values onto stack)
+        DataType[] paramTypes = constructor.getParameterTypes();
+        for (int i = 0; i < args.length; i++) {
+            Compilable argCompiler = AstCompilerFactory.getCompiler(args[i]);
+            argCompiler.compile(mv, ctx);
+
+            // Type promotion and boxing
+            DataType argType = argTypes[i];
+            DataType paramType = paramTypes[i];
+            if (paramType == SystemDataType.DOUBLE && argType == SystemDataType.INT) {
+                mv.visitInsn(Opcodes.I2D);
+            } else if (paramType == SystemDataType.ANY) {
+                boxPrimitive(mv, argType);
+            }
+        }
+
+        // Emit INVOKESPECIAL to call constructor
+        mv.visitMethodInsn(
+            Opcodes.INVOKESPECIAL,
+            extType.getInternalName(),
+            "<init>",
+            constructor.getDescriptor(),
+            false
+        );
+        // Result: new instance reference is on the stack
+    }
+
+    /**
+     * Box a primitive type to its wrapper class.
+     */
+    private void boxPrimitive(MethodVisitor mv, DataType type) {
+        if (type == SystemDataType.INT) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf",
+                "(I)Ljava/lang/Integer;", false);
+        } else if (type == SystemDataType.BOOLEAN) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Boolean", "valueOf",
+                "(Z)Ljava/lang/Boolean;", false);
+        } else if (type == SystemDataType.DOUBLE) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Double", "valueOf",
+                "(D)Ljava/lang/Double;", false);
+        }
     }
 }

--- a/core/src/main/java/com/elminster/jcp/compile/function/MethodCallCompiler.java
+++ b/core/src/main/java/com/elminster/jcp/compile/function/MethodCallCompiler.java
@@ -13,6 +13,8 @@ import com.elminster.jcp.compile.factory.AstCompilerFactory;
 import com.elminster.jcp.compile.util.TypeMapper;
 import com.elminster.jcp.eval.data.DataType;
 import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.ExternalClassType;
+import com.elminster.jcp.eval.data.ExternalMethodDef;
 import com.elminster.jcp.eval.data.StructType;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -40,12 +42,8 @@ public class MethodCallCompiler extends AbstractAstCompiler {
         Compilable targetCompiler = AstCompilerFactory.getCompiler(targetExpr);
         targetCompiler.compile(mv, ctx);
 
-        // 2. Determine the struct type of the target
+        // 2. Determine the type of the target
         DataType targetType = TypeMapper.getExpressionType(targetExpr, ctx);
-        if (!(targetType instanceof StructType)) {
-            throw new CompileException("Cannot call method on non-struct type: " + targetType);
-        }
-        StructType structType = (StructType) targetType;
 
         // 3. Determine argument types for overload resolution
         DataType[] argTypes = new DataType[args.length];
@@ -53,7 +51,64 @@ public class MethodCallCompiler extends AbstractAstCompiler {
             argTypes[i] = TypeMapper.getExpressionType(args[i], ctx);
         }
 
-        // 4. Look up method with overload resolution (supports type hierarchy)
+        // 4. Handle different type kinds
+        if (targetType instanceof ExternalClassType) {
+            compileExternalClassCall(mv, ctx, (ExternalClassType) targetType, methodName, args, argTypes);
+        } else if (targetType instanceof StructType) {
+            compileStructTypeCall(mv, ctx, (StructType) targetType, methodName, args, argTypes);
+        } else {
+            throw new CompileException("Cannot call method on type: " + targetType);
+        }
+    }
+
+    /**
+     * Compile instance method call on ExternalClassType (external Java class).
+     */
+    private void compileExternalClassCall(MethodVisitor mv, CompileContext ctx,
+                                          ExternalClassType extType, String methodName,
+                                          Expression[] args, DataType[] argTypes) {
+        // Look up instance method with overload resolution
+        ExternalMethodDef method = extType.getInstanceMethod(methodName, argTypes);
+        if (method == null) {
+            throw new CompileException("Method '" + methodName +
+                "' with argument types " + Arrays.toString(argTypes) +
+                " not found in type '" + extType.getName() + "'");
+        }
+
+        // Compile arguments (push values onto stack)
+        DataType[] paramTypes = method.getParameterTypes();
+        for (int i = 0; i < args.length; i++) {
+            Compilable argCompiler = AstCompilerFactory.getCompiler(args[i]);
+            argCompiler.compile(mv, ctx);
+
+            // Type promotion and boxing
+            DataType argType = argTypes[i];
+            DataType paramType = paramTypes[i];
+            if (paramType == SystemDataType.DOUBLE && argType == SystemDataType.INT) {
+                mv.visitInsn(Opcodes.I2D);
+            } else if (paramType == SystemDataType.ANY) {
+                // Box primitives when passing to Object parameter
+                boxPrimitive(mv, argType);
+            }
+        }
+
+        // Emit INVOKEVIRTUAL with actual Java class internal name
+        mv.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            extType.getInternalName(),
+            methodName,
+            method.getDescriptor(),
+            false
+        );
+    }
+
+    /**
+     * Compile instance method call on StructType (user-defined type).
+     */
+    private void compileStructTypeCall(MethodVisitor mv, CompileContext ctx,
+                                       StructType structType, String methodName,
+                                       Expression[] args, DataType[] argTypes) {
+        // Look up method with overload resolution (supports type hierarchy)
         MethodDef method = structType.getInstanceMethod(methodName, argTypes);
         if (method == null) {
             throw new CompileException("Method '" + methodName +
@@ -61,7 +116,7 @@ public class MethodCallCompiler extends AbstractAstCompiler {
                 " not found in type '" + structType.getName() + "'");
         }
 
-        // 5. Compile arguments (push values onto stack)
+        // Compile arguments (push values onto stack)
         ParameterDef[] params = method.getParameters();
         for (int i = 0; i < args.length; i++) {
             Compilable argCompiler = AstCompilerFactory.getCompiler(args[i]);
@@ -75,10 +130,10 @@ public class MethodCallCompiler extends AbstractAstCompiler {
             }
         }
 
-        // 6. Build method descriptor
+        // Build method descriptor
         String descriptor = buildMethodDescriptor(params, method.getReturnType());
 
-        // 7. Emit INVOKEVIRTUAL
+        // Emit INVOKEVIRTUAL
         mv.visitMethodInsn(
             Opcodes.INVOKEVIRTUAL,
             structType.getName(),
@@ -86,7 +141,6 @@ public class MethodCallCompiler extends AbstractAstCompiler {
             descriptor,
             false
         );
-        // Result (if any) is now on stack
     }
 
     /**
@@ -102,5 +156,23 @@ public class MethodCallCompiler extends AbstractAstCompiler {
         sb.append(")");
         sb.append(TypeMapper.toDescriptor(returnType));
         return sb.toString();
+    }
+
+    /**
+     * Box a primitive type to its wrapper class.
+     * INT -> Integer, BOOLEAN -> Boolean, DOUBLE -> Double
+     */
+    private void boxPrimitive(MethodVisitor mv, DataType type) {
+        if (type == SystemDataType.INT) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf",
+                "(I)Ljava/lang/Integer;", false);
+        } else if (type == SystemDataType.BOOLEAN) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Boolean", "valueOf",
+                "(Z)Ljava/lang/Boolean;", false);
+        } else if (type == SystemDataType.DOUBLE) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Double", "valueOf",
+                "(D)Ljava/lang/Double;", false);
+        }
+        // String and Object types don't need boxing
     }
 }

--- a/core/src/main/java/com/elminster/jcp/compile/function/StaticMethodCallCompiler.java
+++ b/core/src/main/java/com/elminster/jcp/compile/function/StaticMethodCallCompiler.java
@@ -13,6 +13,8 @@ import com.elminster.jcp.compile.factory.AstCompilerFactory;
 import com.elminster.jcp.compile.util.TypeMapper;
 import com.elminster.jcp.eval.data.DataType;
 import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.ExternalClassType;
+import com.elminster.jcp.eval.data.ExternalMethodDef;
 import com.elminster.jcp.eval.data.StructType;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -38,10 +40,9 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
 
         // 1. Look up the type
         DataType dataType = ctx.getDataType(typeName);
-        if (!(dataType instanceof StructType)) {
-            throw new CompileException("Type not found or not a struct type: " + typeName);
+        if (dataType == null) {
+            throw new CompileException("Type not found: " + typeName);
         }
-        StructType structType = (StructType) dataType;
 
         // 2. Determine argument types for overload resolution
         DataType[] argTypes = new DataType[args.length];
@@ -49,7 +50,64 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
             argTypes[i] = TypeMapper.getExpressionType(args[i], ctx);
         }
 
-        // 3. Look up static method with overload resolution
+        // 3. Handle different type kinds
+        if (dataType instanceof ExternalClassType) {
+            compileExternalClassCall(mv, ctx, (ExternalClassType) dataType, methodName, args, argTypes);
+        } else if (dataType instanceof StructType) {
+            compileStructTypeCall(mv, ctx, (StructType) dataType, typeName, methodName, args, argTypes);
+        } else {
+            throw new CompileException("Type does not support static methods: " + typeName);
+        }
+    }
+
+    /**
+     * Compile static method call on ExternalClassType (external Java class).
+     */
+    private void compileExternalClassCall(MethodVisitor mv, CompileContext ctx,
+                                          ExternalClassType extType, String methodName,
+                                          Expression[] args, DataType[] argTypes) {
+        // Look up static method with overload resolution
+        ExternalMethodDef method = extType.getStaticMethod(methodName, argTypes);
+        if (method == null) {
+            throw new CompileException("Static method '" + methodName +
+                "' with argument types " + Arrays.toString(argTypes) +
+                " not found in type '" + extType.getName() + "'");
+        }
+
+        // Compile arguments (push values onto stack)
+        DataType[] paramTypes = method.getParameterTypes();
+        for (int i = 0; i < args.length; i++) {
+            Compilable argCompiler = AstCompilerFactory.getCompiler(args[i]);
+            argCompiler.compile(mv, ctx);
+
+            // Type promotion and boxing
+            DataType argType = argTypes[i];
+            DataType paramType = paramTypes[i];
+            if (paramType == SystemDataType.DOUBLE && argType == SystemDataType.INT) {
+                mv.visitInsn(Opcodes.I2D);
+            } else if (paramType == SystemDataType.ANY) {
+                // Box primitives when passing to Object parameter
+                boxPrimitive(mv, argType);
+            }
+        }
+
+        // Emit INVOKESTATIC with actual Java class internal name
+        mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            extType.getInternalName(),
+            methodName,
+            method.getDescriptor(),
+            false
+        );
+    }
+
+    /**
+     * Compile static method call on StructType (user-defined type).
+     */
+    private void compileStructTypeCall(MethodVisitor mv, CompileContext ctx,
+                                       StructType structType, String typeName,
+                                       String methodName, Expression[] args, DataType[] argTypes) {
+        // Look up static method with overload resolution
         MethodDef method = structType.getStaticMethod(methodName, argTypes);
         if (method == null) {
             throw new CompileException("Static method '" + methodName +
@@ -57,7 +115,7 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
                 " not found in type '" + typeName + "'");
         }
 
-        // 4. Compile arguments (push values onto stack)
+        // Compile arguments (push values onto stack)
         ParameterDef[] params = method.getParameters();
         for (int i = 0; i < args.length; i++) {
             Compilable argCompiler = AstCompilerFactory.getCompiler(args[i]);
@@ -71,10 +129,10 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
             }
         }
 
-        // 5. Build method descriptor
+        // Build method descriptor
         String descriptor = buildMethodDescriptor(params, method.getReturnType());
 
-        // 6. Emit INVOKESTATIC
+        // Emit INVOKESTATIC
         mv.visitMethodInsn(
             Opcodes.INVOKESTATIC,
             typeName,
@@ -82,7 +140,6 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
             descriptor,
             false
         );
-        // Result (if any) is now on stack
     }
 
     /**
@@ -98,5 +155,23 @@ public class StaticMethodCallCompiler extends AbstractAstCompiler {
         sb.append(")");
         sb.append(TypeMapper.toDescriptor(returnType));
         return sb.toString();
+    }
+
+    /**
+     * Box a primitive type to its wrapper class.
+     * INT -> Integer, BOOLEAN -> Boolean, DOUBLE -> Double
+     */
+    private void boxPrimitive(MethodVisitor mv, DataType type) {
+        if (type == SystemDataType.INT) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf",
+                "(I)Ljava/lang/Integer;", false);
+        } else if (type == SystemDataType.BOOLEAN) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Boolean", "valueOf",
+                "(Z)Ljava/lang/Boolean;", false);
+        } else if (type == SystemDataType.DOUBLE) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Double", "valueOf",
+                "(D)Ljava/lang/Double;", false);
+        }
+        // String and Object types don't need boxing
     }
 }

--- a/core/src/main/java/com/elminster/jcp/compile/util/CompileModeClassConverter.java
+++ b/core/src/main/java/com/elminster/jcp/compile/util/CompileModeClassConverter.java
@@ -1,0 +1,148 @@
+package com.elminster.jcp.compile.util;
+
+import com.elminster.jcp.compile.context.CompileContext;
+import com.elminster.jcp.eval.data.DataType;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.ExternalClassType;
+import com.elminster.jcp.eval.data.ExternalMethodDef;
+import org.objectweb.asm.Type;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Utility class for registering external Java classes in compile mode.
+ * Analyzes Java classes via reflection and creates ExternalClassType instances
+ * that can be used for method call compilation.
+ */
+public final class CompileModeClassConverter {
+
+    private CompileModeClassConverter() {
+    }
+
+    /**
+     * Register a Java class for use in compiled JCP code.
+     * Analyzes the class via reflection and registers all public methods.
+     *
+     * @param clazz  the Java class to register
+     * @param ctx    the compile context
+     * @param module the module name (for namespacing)
+     */
+    public static void registerClass(Class<?> clazz, CompileContext ctx, String module) {
+        String name = clazz.getSimpleName();
+
+        // Create ExternalClassType
+        ExternalClassType type = new ExternalClassType(name, clazz);
+
+        // Analyze and register all public methods
+        Method[] methods = clazz.getDeclaredMethods();
+        for (Method method : methods) {
+            if (Modifier.isPublic(method.getModifiers())) {
+                ExternalMethodDef methodDef = createMethodDef(method);
+                if (Modifier.isStatic(method.getModifiers())) {
+                    type.addStaticMethod(methodDef);
+                } else {
+                    type.addInstanceMethod(methodDef);
+                }
+            }
+        }
+
+        // Analyze and register all public constructors
+        Constructor<?>[] constructors = clazz.getConstructors();
+        for (Constructor<?> constructor : constructors) {
+            if (Modifier.isPublic(constructor.getModifiers())) {
+                ExternalMethodDef ctorDef = createConstructorDef(constructor, type);
+                type.addConstructor(ctorDef);
+            }
+        }
+
+        // Register the type in compile context
+        ctx.addDataType(type);
+    }
+
+    /**
+     * Create an ExternalMethodDef from a Java Method.
+     */
+    private static ExternalMethodDef createMethodDef(Method method) {
+        String name = method.getName();
+        boolean isStatic = Modifier.isStatic(method.getModifiers());
+
+        // Convert Java parameter types to JCP DataTypes
+        Class<?>[] javaParams = method.getParameterTypes();
+        DataType[] paramTypes = new DataType[javaParams.length];
+        for (int i = 0; i < javaParams.length; i++) {
+            paramTypes[i] = mapJavaTypeToDataType(javaParams[i]);
+        }
+
+        // Convert Java return type to JCP DataType
+        DataType returnType = mapJavaTypeToDataType(method.getReturnType());
+
+        // Build JVM method descriptor
+        String descriptor = Type.getMethodDescriptor(method);
+
+        return new ExternalMethodDef(method, name, paramTypes, returnType, descriptor, isStatic);
+    }
+
+    /**
+     * Create an ExternalMethodDef from a Java Constructor.
+     */
+    private static ExternalMethodDef createConstructorDef(Constructor<?> constructor, ExternalClassType type) {
+        // Convert Java parameter types to JCP DataTypes
+        Class<?>[] javaParams = constructor.getParameterTypes();
+        DataType[] paramTypes = new DataType[javaParams.length];
+        for (int i = 0; i < javaParams.length; i++) {
+            paramTypes[i] = mapJavaTypeToDataType(javaParams[i]);
+        }
+
+        // Constructor returns the class type itself
+        DataType returnType = type;
+
+        // Build JVM constructor descriptor
+        String descriptor = Type.getConstructorDescriptor(constructor);
+
+        // Note: Constructor doesn't have a Java Method, so we pass null
+        // The descriptor is enough for bytecode generation
+        return new ExternalMethodDef(null, "<init>", paramTypes, returnType, descriptor, false);
+    }
+
+    /**
+     * Map a Java type to a JCP DataType.
+     */
+    public static DataType mapJavaTypeToDataType(Class<?> javaType) {
+        // Primitive types
+        if (javaType == int.class || javaType == Integer.class) {
+            return SystemDataType.INT;
+        }
+        if (javaType == double.class || javaType == Double.class) {
+            return SystemDataType.DOUBLE;
+        }
+        if (javaType == boolean.class || javaType == Boolean.class) {
+            return SystemDataType.BOOLEAN;
+        }
+        if (javaType == void.class || javaType == Void.class) {
+            return SystemDataType.VOID;
+        }
+        if (javaType == String.class) {
+            return SystemDataType.STRING;
+        }
+
+        // Array types
+        if (javaType == int[].class) {
+            return SystemDataType.INT_ARRAY;
+        }
+        if (javaType == double[].class) {
+            return SystemDataType.DOUBLE_ARRAY;
+        }
+        if (javaType == boolean[].class) {
+            return SystemDataType.BOOLEAN_ARRAY;
+        }
+        if (javaType == String[].class) {
+            return SystemDataType.STRING_ARRAY;
+        }
+
+        // Object and other types map to ANY
+        // This allows parameters like Object to accept any JCP value
+        return SystemDataType.ANY;
+    }
+}

--- a/core/src/main/java/com/elminster/jcp/compile/util/TypeMapper.java
+++ b/core/src/main/java/com/elminster/jcp/compile/util/TypeMapper.java
@@ -107,6 +107,12 @@ public final class TypeMapper {
         if (type instanceof com.elminster.jcp.eval.data.StructType) {
             return "L" + type.getName() + ";";
         }
+        // For external Java classes, use the actual JVM internal name
+        if (type instanceof com.elminster.jcp.eval.data.ExternalClassType) {
+            com.elminster.jcp.eval.data.ExternalClassType extType =
+                (com.elminster.jcp.eval.data.ExternalClassType) type;
+            return "L" + extType.getInternalName() + ";";
+        }
         // Default to Object for ANY or unknown types
         return "Ljava/lang/Object;";
     }

--- a/core/src/main/java/com/elminster/jcp/eval/data/ExternalClassType.java
+++ b/core/src/main/java/com/elminster/jcp/eval/data/ExternalClassType.java
@@ -1,0 +1,208 @@
+package com.elminster.jcp.eval.data;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DataType implementation for external Java classes.
+ * Used in compile mode to represent Java classes whose methods can be called
+ * from compiled JCP code via INVOKESTATIC or INVOKEVIRTUAL.
+ */
+public class ExternalClassType implements DataType {
+
+    private final String name;
+    private final Class<?> javaClass;
+    private final Map<String, List<ExternalMethodDef>> staticMethods;
+    private final Map<String, List<ExternalMethodDef>> instanceMethods;
+    private final List<ExternalMethodDef> constructors;
+
+    public ExternalClassType(String name, Class<?> javaClass) {
+        this.name = name;
+        this.javaClass = javaClass;
+        this.staticMethods = new HashMap<>();
+        this.instanceMethods = new HashMap<>();
+        this.constructors = new ArrayList<>();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public DataType getParent() {
+        return SystemDataType.ANY;
+    }
+
+    public Class<?> getJavaClass() {
+        return javaClass;
+    }
+
+    /**
+     * Get the JVM internal name for this class (e.g., "com/elminster/jcp/module/base/logger/Logger").
+     */
+    public String getInternalName() {
+        return javaClass.getName().replace('.', '/');
+    }
+
+    /**
+     * Add a static method to this type.
+     */
+    public void addStaticMethod(ExternalMethodDef method) {
+        staticMethods.computeIfAbsent(method.getName(), k -> new ArrayList<>()).add(method);
+    }
+
+    /**
+     * Add an instance method to this type.
+     */
+    public void addInstanceMethod(ExternalMethodDef method) {
+        instanceMethods.computeIfAbsent(method.getName(), k -> new ArrayList<>()).add(method);
+    }
+
+    /**
+     * Add a constructor to this type.
+     */
+    public void addConstructor(ExternalMethodDef constructor) {
+        constructors.add(constructor);
+    }
+
+    /**
+     * Get constructor by argument types with overload resolution.
+     * Returns null if no matching constructor found.
+     */
+    public ExternalMethodDef getConstructor(DataType[] argTypes) {
+        List<ExternalMethodDef> matches = new ArrayList<>();
+        for (ExternalMethodDef ctor : constructors) {
+            DataType[] params = ctor.getParameterTypes();
+
+            if (params.length != argTypes.length) {
+                continue;
+            }
+
+            boolean compatible = true;
+            for (int i = 0; i < params.length; i++) {
+                if (!argTypes[i].isCastableTo(params[i])) {
+                    compatible = false;
+                    break;
+                }
+            }
+
+            if (compatible) {
+                matches.add(ctor);
+            }
+        }
+
+        if (matches.isEmpty()) {
+            return null;
+        } else if (matches.size() == 1) {
+            return matches.get(0);
+        } else {
+            throw new IllegalArgumentException(
+                String.format("Ambiguous constructor call: multiple constructors match the argument types"));
+        }
+    }
+
+    /**
+     * Get static method by name and argument types with overload resolution.
+     * Returns null if no matching method found.
+     *
+     * @throws IllegalArgumentException if multiple methods match (ambiguity)
+     */
+    public ExternalMethodDef getStaticMethod(String methodName, DataType[] argTypes) {
+        return findMethodWithOverloadResolution(methodName, argTypes, staticMethods);
+    }
+
+    /**
+     * Get instance method by name and argument types with overload resolution.
+     * Returns null if no matching method found.
+     *
+     * @throws IllegalArgumentException if multiple methods match (ambiguity)
+     */
+    public ExternalMethodDef getInstanceMethod(String methodName, DataType[] argTypes) {
+        return findMethodWithOverloadResolution(methodName, argTypes, instanceMethods);
+    }
+
+    /**
+     * Find a method using overload resolution similar to StructType.
+     * 1. Collect all candidates with matching name
+     * 2. Filter by parameter count
+     * 3. Filter by parameter compatibility (isCastableTo)
+     * 4. Return single match, or throw ambiguity error, or return null if no match
+     */
+    private ExternalMethodDef findMethodWithOverloadResolution(
+            String methodName, DataType[] argTypes, Map<String, List<ExternalMethodDef>> methods) {
+
+        List<ExternalMethodDef> candidates = methods.getOrDefault(methodName, Collections.emptyList());
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        List<ExternalMethodDef> matches = new ArrayList<>();
+        for (ExternalMethodDef method : candidates) {
+            DataType[] params = method.getParameterTypes();
+
+            // Filter by parameter count
+            if (params.length != argTypes.length) {
+                continue;
+            }
+
+            // Filter by parameter compatibility (type hierarchy support)
+            boolean compatible = true;
+            for (int i = 0; i < params.length; i++) {
+                if (!argTypes[i].isCastableTo(params[i])) {
+                    compatible = false;
+                    break;
+                }
+            }
+
+            if (compatible) {
+                matches.add(method);
+            }
+        }
+
+        if (matches.isEmpty()) {
+            return null;
+        } else if (matches.size() == 1) {
+            return matches.get(0);
+        } else {
+            throw new IllegalArgumentException(
+                String.format("Ambiguous method call: multiple methods named '%s' match the argument types",
+                    methodName));
+        }
+    }
+
+    /**
+     * Get all static methods (for debugging/inspection).
+     */
+    public Map<String, List<ExternalMethodDef>> getStaticMethods() {
+        return Collections.unmodifiableMap(staticMethods);
+    }
+
+    /**
+     * Get all instance methods (for debugging/inspection).
+     */
+    public Map<String, List<ExternalMethodDef>> getInstanceMethods() {
+        return Collections.unmodifiableMap(instanceMethods);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        ExternalClassType that = (ExternalClassType) obj;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalClassType{" + name + "}";
+    }
+}

--- a/core/src/main/java/com/elminster/jcp/eval/data/ExternalMethodDef.java
+++ b/core/src/main/java/com/elminster/jcp/eval/data/ExternalMethodDef.java
@@ -1,0 +1,61 @@
+package com.elminster.jcp.eval.data;
+
+import java.lang.reflect.Method;
+
+/**
+ * Stores method signature information for external Java methods.
+ * Used by ExternalClassType to represent methods on external Java classes
+ * that can be called from compiled JCP code.
+ */
+public class ExternalMethodDef {
+
+    private final Method javaMethod;
+    private final String name;
+    private final DataType[] parameterTypes;
+    private final DataType returnType;
+    private final String descriptor;
+    private final boolean isStatic;
+
+    public ExternalMethodDef(Method javaMethod, String name, DataType[] parameterTypes,
+                             DataType returnType, String descriptor, boolean isStatic) {
+        this.javaMethod = javaMethod;
+        this.name = name;
+        this.parameterTypes = parameterTypes;
+        this.returnType = returnType;
+        this.descriptor = descriptor;
+        this.isStatic = isStatic;
+    }
+
+    public Method getJavaMethod() {
+        return javaMethod;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public DataType[] getParameterTypes() {
+        return parameterTypes;
+    }
+
+    public DataType getReturnType() {
+        return returnType;
+    }
+
+    public String getDescriptor() {
+        return descriptor;
+    }
+
+    public boolean isStatic() {
+        return isStatic;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalMethodDef{" +
+            "name='" + name + '\'' +
+            ", descriptor='" + descriptor + '\'' +
+            ", isStatic=" + isStatic +
+            '}';
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/compile/module/AssertionsCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/AssertionsCompileTest.java
@@ -1,0 +1,91 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
+import com.elminster.jcp.ast.expression.literal.BooleanLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.compile.AbstractCompileTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Assertions module type in compile mode.
+ * Verifies that Assertions.assertTrue() can be called from compiled JCP code.
+ */
+public class AssertionsCompileTest extends AbstractCompileTest {
+
+    @Test
+    void testAssertTrueWithTrue() throws Exception {
+        // Assertions.assertTrue(true);
+        Block program = new BlockImpl();
+
+        StaticMethodCallExpression assertCall = new StaticMethodCallExpression(
+            "Assertions",
+            "assertTrue",
+            LiteralExpression.of(BooleanLiteral.of(true))
+        );
+        program.addStatement(new ExpressionStatement(assertCall));
+
+        // Compile and run
+        String className = uniqueClassName("TestAssertTrueWithTrue");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testAssertTrueWithFalse() throws Exception {
+        // Assertions.assertTrue(false); - should throw
+        Block program = new BlockImpl();
+
+        StaticMethodCallExpression assertCall = new StaticMethodCallExpression(
+            "Assertions",
+            "assertTrue",
+            LiteralExpression.of(BooleanLiteral.of(false))
+        );
+        program.addStatement(new ExpressionStatement(assertCall));
+
+        // Compile and run
+        String className = uniqueClassName("TestAssertTrueWithFalse");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should throw AssertException
+        InvocationTargetException ex = assertThrows(
+            InvocationTargetException.class,
+            () -> mainMethod.invoke(null, (Object) new String[]{})
+        );
+        assertTrue(ex.getCause().getMessage().contains("Assertions failed"));
+    }
+
+    @Test
+    void testMultipleAssertions() throws Exception {
+        // Assertions.assertTrue(true);
+        // Assertions.assertTrue(true);
+        Block program = new BlockImpl();
+
+        program.addStatement(new ExpressionStatement(new StaticMethodCallExpression(
+            "Assertions", "assertTrue", LiteralExpression.of(BooleanLiteral.of(true))
+        )));
+        program.addStatement(new ExpressionStatement(new StaticMethodCallExpression(
+            "Assertions", "assertTrue", LiteralExpression.of(BooleanLiteral.of(true))
+        )));
+
+        // Compile and run
+        String className = uniqueClassName("TestMultipleAssertions");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/compile/module/LoggerCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/LoggerCompileTest.java
@@ -1,0 +1,91 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
+import com.elminster.jcp.ast.expression.literal.IntLiteral;
+import com.elminster.jcp.ast.expression.literal.StringLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.compile.AbstractCompileTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Logger module type in compile mode.
+ * Verifies that Logger.log() can be called from compiled JCP code.
+ */
+public class LoggerCompileTest extends AbstractCompileTest {
+
+    @Test
+    void testLoggerLogString() throws Exception {
+        // Logger.log("Hello, World!");
+        Block program = new BlockImpl();
+
+        StaticMethodCallExpression logCall = new StaticMethodCallExpression(
+            "Logger",
+            "log",
+            LiteralExpression.of(StringLiteral.of("Hello from compile mode!"))
+        );
+        program.addStatement(new ExpressionStatement(logCall));
+
+        // Compile and run
+        String className = uniqueClassName("TestLoggerLogString");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testLoggerLogInt() throws Exception {
+        // Logger.log(42);
+        Block program = new BlockImpl();
+
+        StaticMethodCallExpression logCall = new StaticMethodCallExpression(
+            "Logger",
+            "log",
+            LiteralExpression.of(IntLiteral.of(42))
+        );
+        program.addStatement(new ExpressionStatement(logCall));
+
+        // Compile and run
+        String className = uniqueClassName("TestLoggerLogInt");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testLoggerMultipleCalls() throws Exception {
+        // Logger.log("First");
+        // Logger.log("Second");
+        // Logger.log(123);
+        Block program = new BlockImpl();
+
+        program.addStatement(new ExpressionStatement(new StaticMethodCallExpression(
+            "Logger", "log", LiteralExpression.of(StringLiteral.of("First"))
+        )));
+        program.addStatement(new ExpressionStatement(new StaticMethodCallExpression(
+            "Logger", "log", LiteralExpression.of(StringLiteral.of("Second"))
+        )));
+        program.addStatement(new ExpressionStatement(new StaticMethodCallExpression(
+            "Logger", "log", LiteralExpression.of(IntLiteral.of(123))
+        )));
+
+        // Compile and run
+        String className = uniqueClassName("TestLoggerMultipleCalls");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/compile/module/ValueBufferCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/ValueBufferCompileTest.java
@@ -1,0 +1,96 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
+import com.elminster.jcp.ast.expression.base.MethodCallExpression;
+import com.elminster.jcp.ast.expression.base.VariableExpression;
+import com.elminster.jcp.ast.expression.literal.IntLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
+import com.elminster.jcp.compile.AbstractCompileTest;
+import com.elminster.jcp.compile.BytecodeGenerator;
+import com.elminster.jcp.compile.MultiClassLoader;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.DataTypeImpl;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ValueBuffer module type in compile mode.
+ * Verifies that ValueBuffer can be constructed and its instance methods called.
+ */
+public class ValueBufferCompileTest extends AbstractCompileTest {
+
+    @Test
+    void testValueBufferNew() throws Exception {
+        // ValueBuffer vb = ValueBuffer.new();
+        Block program = new BlockImpl();
+
+        FunctionCallExpression ctorCall = new FunctionCallExpression(
+            Identifier.fromName("ValueBuffer.new")
+        );
+        VariableDeclarationImpl vbDecl = new VariableDeclarationImpl(
+            "vb",
+            new DataTypeImpl("ValueBuffer"),
+            ctorCall
+        );
+        program.addStatement(vbDecl);
+
+        // Compile and run
+        String className = uniqueClassName("TestValueBufferNew");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method mainMethod = clazz.getMethod("main", String[].class);
+
+        // Should execute without throwing
+        assertDoesNotThrow(() -> mainMethod.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testValueBufferLength() throws Exception {
+        // ValueBuffer vb = ValueBuffer.new();
+        // int len = vb.length();  // Should be 0 for empty buffer
+        Block program = new BlockImpl();
+
+        // Create ValueBuffer
+        FunctionCallExpression ctorCall = new FunctionCallExpression(
+            Identifier.fromName("ValueBuffer.new")
+        );
+        VariableDeclarationImpl vbDecl = new VariableDeclarationImpl(
+            "vb",
+            new DataTypeImpl("ValueBuffer"),
+            ctorCall
+        );
+        program.addStatement(vbDecl);
+
+        // Call vb.length()
+        MethodCallExpression lengthCall = new MethodCallExpression(
+            VariableExpression.of("vb"),
+            "length"
+        );
+
+        // Compile with return to get the length value
+        String className = uniqueClassName("TestValueBufferLength");
+        BytecodeGenerator generator = new BytecodeGenerator(className);
+        byte[] bytecode = generator.compileWithReturn(program, lengthCall, SystemDataType.INT);
+
+        Map<String, byte[]> genClasses = generator.getGeneratedClasses();
+        MultiClassLoader loader = new MultiClassLoader();
+        for (Map.Entry<String, byte[]> entry : genClasses.entrySet()) {
+            loader.defineClass(entry.getKey(), entry.getValue());
+        }
+        loader.defineClass(className, bytecode);
+        Class<?> clazz = loader.loadClass(className);
+
+        Method evaluate = clazz.getMethod("evaluate");
+        int result = (int) evaluate.invoke(null);
+        assertEquals(0, result);  // Empty buffer has length 0
+    }
+}


### PR DESCRIPTION
## Summary

Enable compiled JCP code to call methods on external Java classes (Logger, Assertions, ValueBuffer) that were previously only available in eval mode.

This PR implements **Phases 1-4** of the Module Type Testing and Compile-Mode ClassConverter plan (#2):

- **Phase 1**: Test infrastructure for module types
- **Phase 2**: ExternalClassType and ExternalMethodDef for compile-time type representation
- **Phase 3**: CompileModeClassConverter utility and compiler extensions
- **Phase 4**: Integration with BytecodeGenerator for automatic module registration

## Changes

### New Files
| File | Purpose |
|------|---------|
| `ExternalMethodDef.java` | Stores method signatures for external Java methods |
| `ExternalClassType.java` | DataType implementation for external Java classes |
| `CompileModeClassConverter.java` | Analyzes Java classes via reflection and registers them |
| `LoggerCompileTest.java` | Tests for Logger.log() in compile mode |
| `AssertionsCompileTest.java` | Tests for Assertions.assertTrue() in compile mode |
| `ValueBufferCompileTest.java` | Tests for ValueBuffer constructor and methods |

### Modified Files
| File | Change |
|------|--------|
| `StaticMethodCallCompiler.java` | Handle ExternalClassType for static method calls |
| `MethodCallCompiler.java` | Handle ExternalClassType for instance method calls |
| `FunCallCompiler.java` | Handle external class constructors (TypeName.new pattern) |
| `TypeMapper.java` | Add descriptor support for ExternalClassType |
| `BytecodeGenerator.java` | Register module types on compilation initialization |

### Key Features
- **Primitive boxing**: Automatically box int/boolean/double when passing to Object parameters
- **Overload resolution**: Find matching method/constructor based on argument types
- **Constructor support**: Handle `TypeName.new(args)` function call pattern

## Testing

```
Tests run: 3 (Logger) + 3 (Assertions) + 2 (ValueBuffer) = 8 new tests
All 117+ tests pass
```

## Acceptance Criteria (from #2)

- [x] Logger.log(Object) works in compile mode
- [x] Assertions.assertTrue(boolean) works in compile mode  
- [x] ValueBuffer instance methods work in compile mode
- [x] All existing tests pass
- [x] New module type tests for compile mode

## Not Included (Phase 5)

Third-party JAR support (`JcpCompiler.addClasspath()`) is deferred to a future PR.

---

Closes #2

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.ai/code)