### PR TITLE
feat: Arrays.sort for struct arrays with SortKey builder

### DIFF
--- a/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
@@ -1,6 +1,7 @@
 package com.elminster.jcp.module.base;
 
 import com.elminster.jcp.module.base.arrays.Arrays;
+import com.elminster.jcp.module.base.arrays.SortKey;
 import com.elminster.jcp.module.base.assertions.Assertions;
 import com.elminster.jcp.module.base.logger.Logger;
 import com.elminster.jcp.module.base.strings.Strings;
@@ -13,6 +14,7 @@ public class BaseModuleRegister {
 
     public static List<Class<?>> classToRegister() {
         List<Class<?>> classes = new ArrayList<>();
+        classes.add(SortKey.class);  // must precede Arrays so SortKey DataType exists when Arrays methods are scanned
         classes.add(Arrays.class);
         classes.add(Assertions.class);
         classes.add(Logger.class);

--- a/core/src/main/java/com/elminster/jcp/module/base/arrays/Arrays.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/arrays/Arrays.java
@@ -173,9 +173,9 @@ public class Arrays {
     }
 
     private static Object[] sortByKeys(Object[] a, SortKey... keys) {
-        java.util.Comparator<Object> comparator = (x, y) -> 0;
-        for (SortKey key : keys) {
-            comparator = comparator.thenComparing(key.toComparator());
+        java.util.Comparator<Object> comparator = keys[0].toComparator();
+        for (int i = 1; i < keys.length; i++) {
+            comparator = comparator.thenComparing(keys[i].toComparator());
         }
         java.util.Arrays.sort(a, comparator);
         return a;
@@ -188,35 +188,45 @@ public class Arrays {
      */
     public static int[] reverse(int[] a) {
         for (int i = 0, j = a.length - 1; i < j; i++, j--) {
-            int tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+            int tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
         }
         return a;
     }
 
     public static String[] reverse(String[] a) {
         for (int i = 0, j = a.length - 1; i < j; i++, j--) {
-            String tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+            String tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
         }
         return a;
     }
 
     public static boolean[] reverse(boolean[] a) {
         for (int i = 0, j = a.length - 1; i < j; i++, j--) {
-            boolean tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+            boolean tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
         }
         return a;
     }
 
     public static double[] reverse(double[] a) {
         for (int i = 0, j = a.length - 1; i < j; i++, j--) {
-            double tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+            double tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
         }
         return a;
     }
 
     public static Object[] reverse(Object[] a) {
         for (int i = 0, j = a.length - 1; i < j; i++, j--) {
-            Object tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+            Object tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
         }
         return a;
     }

--- a/core/src/main/java/com/elminster/jcp/module/base/arrays/Arrays.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/arrays/Arrays.java
@@ -16,6 +16,9 @@ import java.util.Objects;
  *   Arrays.slice(a, 1, 3)
  *   Arrays.contains(a, v)
  *   Arrays.sort(a)
+ *   Arrays.sort(persons, SortKey.by("age"))
+ *   Arrays.sort(persons, SortKey.by("lastName"), SortKey.by("firstName"))
+ *   Arrays.reverse(a)
  *   base::Arrays.length(a)  // explicit module form
  * </pre>
  *
@@ -138,11 +141,83 @@ public class Arrays {
      * Sorts the array in-place and returns it.
      *
      * <p>Elements must implement {@link Comparable}; throws {@link ClassCastException} otherwise.
-     * JCP custom types (structs) do not implement {@code Comparable} and cannot be sorted with
-     * this method. A comparator-based overload will be added once JCP supports function references.
+     * For struct arrays, use the {@link SortKey}-based overloads instead.
      */
     public static Object[] sort(Object[] a) {
         java.util.Arrays.sort(a);
+        return a;
+    }
+
+    /**
+     * Sorts a struct array in-place by a single field and returns it.
+     * Elements whose field is missing or non-navigable sort last.
+     */
+    public static Object[] sort(Object[] a, SortKey k1) {
+        return sortByKeys(a, k1);
+    }
+
+    /**
+     * Sorts a struct array in-place by two fields (primary, secondary) and returns it.
+     * Elements whose field is missing or non-navigable sort last.
+     */
+    public static Object[] sort(Object[] a, SortKey k1, SortKey k2) {
+        return sortByKeys(a, k1, k2);
+    }
+
+    /**
+     * Sorts a struct array in-place by three fields and returns it.
+     * Elements whose field is missing or non-navigable sort last.
+     */
+    public static Object[] sort(Object[] a, SortKey k1, SortKey k2, SortKey k3) {
+        return sortByKeys(a, k1, k2, k3);
+    }
+
+    private static Object[] sortByKeys(Object[] a, SortKey... keys) {
+        java.util.Comparator<Object> comparator = (x, y) -> 0;
+        for (SortKey key : keys) {
+            comparator = comparator.thenComparing(key.toComparator());
+        }
+        java.util.Arrays.sort(a, comparator);
+        return a;
+    }
+
+    // --- reverse ---
+
+    /**
+     * Reverses the array in-place and returns it.
+     */
+    public static int[] reverse(int[] a) {
+        for (int i = 0, j = a.length - 1; i < j; i++, j--) {
+            int tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
+        return a;
+    }
+
+    public static String[] reverse(String[] a) {
+        for (int i = 0, j = a.length - 1; i < j; i++, j--) {
+            String tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
+        return a;
+    }
+
+    public static boolean[] reverse(boolean[] a) {
+        for (int i = 0, j = a.length - 1; i < j; i++, j--) {
+            boolean tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
+        return a;
+    }
+
+    public static double[] reverse(double[] a) {
+        for (int i = 0, j = a.length - 1; i < j; i++, j--) {
+            double tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
+        return a;
+    }
+
+    public static Object[] reverse(Object[] a) {
+        for (int i = 0, j = a.length - 1; i < j; i++, j--) {
+            Object tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
         return a;
     }
 }

--- a/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
@@ -27,28 +27,33 @@ import java.util.Comparator;
 public class SortKey {
 
     private final String fieldPath;
-    private boolean descending;
+    private final boolean descending;
 
-    private SortKey(String fieldPath) {
+    private SortKey(String fieldPath, boolean descending) {
         this.fieldPath = fieldPath;
-        this.descending = false;
+        this.descending = descending;
     }
 
-    /** Creates a sort key for the given field path, ascending by default. */
+    /**
+     * Creates a sort key for the given field path, ascending by default.
+     *
+     * @throws IllegalArgumentException if {@code fieldPath} is null or empty
+     */
     public static SortKey by(String fieldPath) {
-        return new SortKey(fieldPath);
+        if (fieldPath == null || fieldPath.isEmpty()) {
+            throw new IllegalArgumentException("fieldPath must not be null or empty");
+        }
+        return new SortKey(fieldPath, false);
     }
 
-    /** Sets direction to ascending. Returns {@code this} for chaining. */
+    /** Returns a new sort key with ascending direction. */
     public SortKey asc() {
-        this.descending = false;
-        return this;
+        return new SortKey(this.fieldPath, false);
     }
 
-    /** Sets direction to descending. Returns {@code this} for chaining. */
+    /** Returns a new sort key with descending direction. */
     public SortKey desc() {
-        this.descending = true;
-        return this;
+        return new SortKey(this.fieldPath, true);
     }
 
     /**

--- a/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
@@ -13,7 +13,9 @@ import java.util.Comparator;
  * {@link Arrays#sort(Object[], SortKey, SortKey, SortKey)}.
  *
  * <p>Field paths use dot notation for nested structs: {@code "address.city"}.
- * Elements whose field is missing or non-navigable sort last regardless of direction.
+ * An illegal field path (intermediate segment missing or not a struct) raises
+ * {@link IllegalArgumentException} during comparison. Elements that are not
+ * {@link StructData} or whose leaf value is missing/non-Comparable sort last.
  *
  * <pre>
  *   SortKey.by("age")               // ascending
@@ -26,12 +28,17 @@ import java.util.Comparator;
  */
 public class SortKey {
 
-    private final String fieldPath;
-    private final boolean descending;
+    /** Sort direction. */
+    public enum Direction {
+        ASC, DESC
+    }
 
-    private SortKey(String fieldPath, boolean descending) {
+    private final String fieldPath;
+    private final Direction direction;
+
+    private SortKey(String fieldPath, Direction direction) {
         this.fieldPath = fieldPath;
-        this.descending = descending;
+        this.direction = direction;
     }
 
     /**
@@ -43,22 +50,26 @@ public class SortKey {
         if (fieldPath == null || fieldPath.isEmpty()) {
             throw new IllegalArgumentException("fieldPath must not be null or empty");
         }
-        return new SortKey(fieldPath, false);
+        return new SortKey(fieldPath, Direction.ASC);
     }
 
     /** Returns a new sort key with ascending direction. */
     public SortKey asc() {
-        return new SortKey(this.fieldPath, false);
+        return new SortKey(this.fieldPath, Direction.ASC);
     }
 
     /** Returns a new sort key with descending direction. */
     public SortKey desc() {
-        return new SortKey(this.fieldPath, true);
+        return new SortKey(this.fieldPath, Direction.DESC);
     }
 
     /**
      * Returns a {@link Comparator} that compares two elements by this key's field path.
-     * Null values (missing or non-navigable fields) sort last in both directions.
+     *
+     * <p>Elements that are not {@link StructData} sort last. Elements whose leaf field is
+     * missing or not {@link Comparable} sort last. An illegal field path — one that
+     * traverses through a non-struct or references a missing intermediate segment —
+     * raises {@link IllegalArgumentException}.
      */
     Comparator<Object> toComparator() {
         return (a, b) -> {
@@ -70,15 +81,16 @@ public class SortKey {
             if (vb == null) return -1;  // nulls last
 
             int cmp = va.compareTo(vb);
-            return descending ? -cmp : cmp;
+            return direction == Direction.DESC ? -cmp : cmp;
         };
     }
 
     /**
      * Resolves the field path from a struct element.
-     * Returns {@code null} if the element is not a {@link StructData}, any path segment is
-     * missing, any intermediate node is not a {@link StructData}, or the leaf value is not
-     * {@link Comparable}.
+     * Returns {@code null} if the element is not a {@link StructData} or the leaf value is
+     * missing/non-{@link Comparable}. Throws {@link IllegalArgumentException} if any
+     * intermediate segment is missing or not a {@link StructData} — that path is illegal
+     * for this element's schema.
      */
     @SuppressWarnings("unchecked")
     private Comparable<Object> resolveField(Object element) {
@@ -91,7 +103,9 @@ public class SortKey {
         for (int i = 0; i < segments.length - 1; i++) {
             Data field = current.getField(segments[i]);
             if (field == null || !(field.get() instanceof StructData)) {
-                return null;
+                throw new IllegalArgumentException(
+                    "Illegal field path '" + fieldPath + "': segment '" + segments[i]
+                        + "' is missing or not a struct");
             }
             current = (StructData) field.get();
         }

--- a/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/arrays/SortKey.java
@@ -1,0 +1,100 @@
+package com.elminster.jcp.module.base.arrays;
+
+import com.elminster.jcp.eval.data.Data;
+import com.elminster.jcp.eval.data.StructData;
+
+import java.util.Comparator;
+
+/**
+ * A sort key for struct array sorting — specifies a field path and direction.
+ *
+ * <p>Used with {@link Arrays#sort(Object[], SortKey)},
+ * {@link Arrays#sort(Object[], SortKey, SortKey)}, and
+ * {@link Arrays#sort(Object[], SortKey, SortKey, SortKey)}.
+ *
+ * <p>Field paths use dot notation for nested structs: {@code "address.city"}.
+ * Elements whose field is missing or non-navigable sort last regardless of direction.
+ *
+ * <pre>
+ *   SortKey.by("age")               // ascending
+ *   SortKey.by("name").desc()       // descending
+ *   SortKey.by("address.city").asc()
+ * </pre>
+ *
+ * @author jgu
+ * @version 1.0
+ */
+public class SortKey {
+
+    private final String fieldPath;
+    private boolean descending;
+
+    private SortKey(String fieldPath) {
+        this.fieldPath = fieldPath;
+        this.descending = false;
+    }
+
+    /** Creates a sort key for the given field path, ascending by default. */
+    public static SortKey by(String fieldPath) {
+        return new SortKey(fieldPath);
+    }
+
+    /** Sets direction to ascending. Returns {@code this} for chaining. */
+    public SortKey asc() {
+        this.descending = false;
+        return this;
+    }
+
+    /** Sets direction to descending. Returns {@code this} for chaining. */
+    public SortKey desc() {
+        this.descending = true;
+        return this;
+    }
+
+    /**
+     * Returns a {@link Comparator} that compares two elements by this key's field path.
+     * Null values (missing or non-navigable fields) sort last in both directions.
+     */
+    Comparator<Object> toComparator() {
+        return (a, b) -> {
+            Comparable<Object> va = resolveField(a);
+            Comparable<Object> vb = resolveField(b);
+
+            if (va == null && vb == null) return 0;
+            if (va == null) return 1;   // nulls last
+            if (vb == null) return -1;  // nulls last
+
+            int cmp = va.compareTo(vb);
+            return descending ? -cmp : cmp;
+        };
+    }
+
+    /**
+     * Resolves the field path from a struct element.
+     * Returns {@code null} if the element is not a {@link StructData}, any path segment is
+     * missing, any intermediate node is not a {@link StructData}, or the leaf value is not
+     * {@link Comparable}.
+     */
+    @SuppressWarnings("unchecked")
+    private Comparable<Object> resolveField(Object element) {
+        if (!(element instanceof StructData)) {
+            return null;
+        }
+        String[] segments = fieldPath.split("\\.");
+        StructData current = (StructData) element;
+
+        for (int i = 0; i < segments.length - 1; i++) {
+            Data field = current.getField(segments[i]);
+            if (field == null || !(field.get() instanceof StructData)) {
+                return null;
+            }
+            current = (StructData) field.get();
+        }
+
+        Data leaf = current.getField(segments[segments.length - 1]);
+        if (leaf == null || !(leaf.get() instanceof Comparable)) {
+            return null;
+        }
+        return (Comparable<Object>) leaf.get();
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/function/ArraysSortStructTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/ArraysSortStructTest.java
@@ -1,0 +1,185 @@
+package com.elminster.jcp.eval.function;
+
+import com.elminster.jcp.ast.Expression;
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
+import com.elminster.jcp.ast.expression.base.VariableExpression;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.declaration.StructFieldDef;
+import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
+import com.elminster.jcp.eval.EvalVisitor;
+import com.elminster.jcp.eval.context.EvalContext;
+import com.elminster.jcp.eval.context.RootEvalContext;
+import com.elminster.jcp.eval.data.AnyData;
+import com.elminster.jcp.eval.data.DataType;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.IntegerData;
+import com.elminster.jcp.eval.data.StringData;
+import com.elminster.jcp.eval.data.StructData;
+import com.elminster.jcp.eval.data.StructType;
+import com.elminster.jcp.module.base.arrays.SortKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@code Arrays.sort(Object[], SortKey...)} overloads via
+ * {@link FunctionCallExpression} dispatch — validates the full JCP runtime path.
+ */
+public class ArraysSortStructTest {
+
+    private StructType personType;
+
+    @BeforeEach
+    void setUp() {
+        personType = new StructType("Person", Arrays.asList(
+            new StructFieldDef("name", SystemDataType.STRING),
+            new StructFieldDef("age", SystemDataType.INT)
+        ));
+    }
+
+    private StructData person(String name, int age) {
+        StructData p = new StructData(Identifier.fromName("p"), personType);
+        p.setField("name", new StringData(name, false));
+        p.setField("age", new IntegerData(age, false));
+        return p;
+    }
+
+    /**
+     * Seeds a struct array and a SortKey in the context, then calls Arrays.sort via
+     * FunctionCallExpression and returns the sorted array.
+     */
+    private Object[] sortViaDispatch(StructData[] persons, SortKey... keys) {
+        EvalContext ctx = new RootEvalContext();
+        DataType sortKeyType = ctx.getDataType("SortKey");
+
+        // Seed array
+        ctx.getVariables().put("arr",
+            new AnyData<>(Identifier.fromName("arr"), SystemDataType.ANY_ARRAY,
+                (Object) persons));
+
+        // Seed each SortKey as a variable with the registered SortKey DataType
+        Expression[] args = new Expression[1 + keys.length];
+        args[0] = VariableExpression.of(Identifier.fromName("arr"));
+        for (int i = 0; i < keys.length; i++) {
+            String varName = "k" + i;
+            ctx.getVariables().put(varName, new AnyData<>(keys[i], sortKeyType));
+            args[1 + i] = VariableExpression.of(Identifier.fromName(varName));
+        }
+
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "result", SystemDataType.ANY_ARRAY,
+            new FunctionCallExpression(Identifier.fromName("Arrays.sort"), args)
+        ));
+        new EvalVisitor(ctx).visit(program);
+        return (Object[]) ctx.getVariable("result").get();
+    }
+
+    // --- 1-key sort ---
+
+    @Test
+    void testSort_oneKey_byAge_asc() {
+        StructData[] persons = {
+            person("Charlie", 30),
+            person("Alice", 10),
+            person("Bob", 20)
+        };
+        Object[] sorted = sortViaDispatch(persons, SortKey.by("age"));
+        assertEquals(10, ((StructData) sorted[0]).getField("age").get());
+        assertEquals(20, ((StructData) sorted[1]).getField("age").get());
+        assertEquals(30, ((StructData) sorted[2]).getField("age").get());
+    }
+
+    @Test
+    void testSort_oneKey_byName_desc() {
+        StructData[] persons = {
+            person("Alice", 1),
+            person("Charlie", 2),
+            person("Bob", 3)
+        };
+        Object[] sorted = sortViaDispatch(persons, SortKey.by("name").desc());
+        assertEquals("Charlie", ((StructData) sorted[0]).getField("name").get());
+        assertEquals("Bob",     ((StructData) sorted[1]).getField("name").get());
+        assertEquals("Alice",   ((StructData) sorted[2]).getField("name").get());
+    }
+
+    // --- 2-key sort ---
+
+    @Test
+    void testSort_twoKeys_sameAge_thenByName() {
+        StructData[] persons = {
+            person("Charlie", 20),
+            person("Alice", 20),
+            person("Bob", 10)
+        };
+        Object[] sorted = sortViaDispatch(persons, SortKey.by("age"), SortKey.by("name"));
+        // Bob (10) first, then Alice (20), then Charlie (20)
+        assertEquals("Bob",     ((StructData) sorted[0]).getField("name").get());
+        assertEquals("Alice",   ((StructData) sorted[1]).getField("name").get());
+        assertEquals("Charlie", ((StructData) sorted[2]).getField("name").get());
+    }
+
+    // --- 3-key sort ---
+
+    @Test
+    void testSort_threeKeys() {
+        StructType t = new StructType("T", Arrays.asList(
+            new StructFieldDef("a", SystemDataType.INT),
+            new StructFieldDef("b", SystemDataType.INT),
+            new StructFieldDef("c", SystemDataType.INT)
+        ));
+        StructData s1 = new StructData(Identifier.fromName("s1"), t);
+        s1.setField("a", new IntegerData(1, false));
+        s1.setField("b", new IntegerData(2, false));
+        s1.setField("c", new IntegerData(3, false));
+        StructData s2 = new StructData(Identifier.fromName("s2"), t);
+        s2.setField("a", new IntegerData(1, false));
+        s2.setField("b", new IntegerData(2, false));
+        s2.setField("c", new IntegerData(1, false));
+
+        EvalContext ctx = new RootEvalContext();
+        DataType sortKeyType = ctx.getDataType("SortKey");
+        ctx.getVariables().put("arr",
+            new AnyData<>(Identifier.fromName("arr"), SystemDataType.ANY_ARRAY,
+                new Object[]{s1, s2}));
+        ctx.getVariables().put("k0", new AnyData<>(SortKey.by("a"), sortKeyType));
+        ctx.getVariables().put("k1", new AnyData<>(SortKey.by("b"), sortKeyType));
+        ctx.getVariables().put("k2", new AnyData<>(SortKey.by("c"), sortKeyType));
+
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "result", SystemDataType.ANY_ARRAY,
+            new FunctionCallExpression(Identifier.fromName("Arrays.sort"),
+                VariableExpression.of(Identifier.fromName("arr")),
+                VariableExpression.of(Identifier.fromName("k0")),
+                VariableExpression.of(Identifier.fromName("k1")),
+                VariableExpression.of(Identifier.fromName("k2")))
+        ));
+        new EvalVisitor(ctx).visit(program);
+        Object[] sorted = (Object[]) ctx.getVariable("result").get();
+
+        // s2 (c=1) before s1 (c=3)
+        assertEquals(1, ((StructData) sorted[0]).getField("c").get());
+        assertEquals(3, ((StructData) sorted[1]).getField("c").get());
+    }
+
+    // --- null-field element sorts last ---
+
+    @Test
+    void testSort_missingField_sortsLast() {
+        StructData withAge = person("Alice", 5);
+        StructData noAge = new StructData(Identifier.fromName("noAge"), personType);
+        noAge.setField("name", new StringData("Bob", false));
+        // "age" field not set → null
+
+        Object[] sorted = sortViaDispatch(new StructData[]{noAge, withAge}, SortKey.by("age"));
+        // withAge (5) first, noAge (null) last
+        assertEquals(5, ((StructData) sorted[0]).getField("age").get());
+        assertNull(((StructData) sorted[1]).getField("age"));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/function/ArraysTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/ArraysTest.java
@@ -189,4 +189,69 @@ public class ArraysTest {
             (double[]) evalOnArray("a", new double[]{3.0, 1.0, 2.0}, SystemDataType.DOUBLE_ARRAY,
                 "sort", SystemDataType.DOUBLE_ARRAY));
     }
+
+    // --- reverse ---
+
+    @Test
+    void testReverse_intArray() {
+        assertArrayEquals(new int[]{3, 2, 1},
+            (int[]) evalOnArray("a", new int[]{1, 2, 3}, SystemDataType.INT_ARRAY,
+                "reverse", SystemDataType.INT_ARRAY));
+    }
+
+    @Test
+    void testReverse_intArray_single() {
+        assertArrayEquals(new int[]{42},
+            (int[]) evalOnArray("a", new int[]{42}, SystemDataType.INT_ARRAY,
+                "reverse", SystemDataType.INT_ARRAY));
+    }
+
+    @Test
+    void testReverse_intArray_empty() {
+        assertArrayEquals(new int[]{},
+            (int[]) evalOnArray("a", new int[]{}, SystemDataType.INT_ARRAY,
+                "reverse", SystemDataType.INT_ARRAY));
+    }
+
+    @Test
+    void testReverse_intArray_even() {
+        assertArrayEquals(new int[]{4, 3, 2, 1},
+            (int[]) evalOnArray("a", new int[]{1, 2, 3, 4}, SystemDataType.INT_ARRAY,
+                "reverse", SystemDataType.INT_ARRAY));
+    }
+
+    @Test
+    void testReverse_intArray_odd() {
+        assertArrayEquals(new int[]{5, 4, 3, 2, 1},
+            (int[]) evalOnArray("a", new int[]{1, 2, 3, 4, 5}, SystemDataType.INT_ARRAY,
+                "reverse", SystemDataType.INT_ARRAY));
+    }
+
+    @Test
+    void testReverse_stringArray() {
+        assertArrayEquals(new String[]{"c", "b", "a"},
+            (String[]) evalOnArray("a", new String[]{"a", "b", "c"}, SystemDataType.STRING_ARRAY,
+                "reverse", SystemDataType.STRING_ARRAY));
+    }
+
+    @Test
+    void testReverse_booleanArray() {
+        assertArrayEquals(new boolean[]{false, true, false},
+            (boolean[]) evalOnArray("a", new boolean[]{false, true, false}, SystemDataType.BOOLEAN_ARRAY,
+                "reverse", SystemDataType.BOOLEAN_ARRAY));
+    }
+
+    @Test
+    void testReverse_doubleArray() {
+        assertArrayEquals(new double[]{3.0, 2.0, 1.0},
+            (double[]) evalOnArray("a", new double[]{1.0, 2.0, 3.0}, SystemDataType.DOUBLE_ARRAY,
+                "reverse", SystemDataType.DOUBLE_ARRAY));
+    }
+
+    @Test
+    void testReverse_objectArray() {
+        assertArrayEquals(new String[]{"z", "y", "x"},
+            (Object[]) evalOnArray("a", new String[]{"x", "y", "z"}, SystemDataType.ANY_ARRAY,
+                "reverse", SystemDataType.ANY_ARRAY));
+    }
 }

--- a/core/src/test/java/com/elminster/jcp/module/base/arrays/SortKeyTest.java
+++ b/core/src/test/java/com/elminster/jcp/module/base/arrays/SortKeyTest.java
@@ -177,17 +177,60 @@ class SortKeyTest {
         assertEquals("Amsterdam", firstAddr.getField("city").get());
     }
 
-    // --- non-struct mid-node → null-last ---
+    // --- illegal field path → IllegalArgumentException ---
 
     @Test
-    void testNestedPath_nonStructMidNode_sortsLast() {
+    void testNestedPath_nonStructMidNode_throws() {
         StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.STRING)));
         StructData s = new StructData(Identifier.fromName("s"), t);
-        // "x" is a String, not a StructData — navigating "x.sub" should null-out
+        // "x" is a String, not a StructData — navigating "x.sub" is an illegal field path
         s.setField("x", new StringData("hello", false));
 
-        Object[] arr = { s };
         Comparator<Object> cmp = SortKey.by("x.sub").toComparator();
-        assertEquals(0, cmp.compare(s, s)); // both resolve null → equal
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> cmp.compare(s, s));
+        assertTrue(ex.getMessage().contains("x.sub"));
+    }
+
+    @Test
+    void testNestedPath_missingMidSegment_throws() {
+        StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.STRING)));
+        StructData s = new StructData(Identifier.fromName("s"), t);
+        // "missing" segment is not present in the struct — illegal path
+        Comparator<Object> cmp = SortKey.by("missing.leaf").toComparator();
+        assertThrows(IllegalArgumentException.class, () -> cmp.compare(s, s));
+    }
+
+    // --- by() rejects null/empty fieldPath ---
+
+    @Test
+    void testBy_nullFieldPath_throws() {
+        assertThrows(IllegalArgumentException.class, () -> SortKey.by(null));
+    }
+
+    @Test
+    void testBy_emptyFieldPath_throws() {
+        assertThrows(IllegalArgumentException.class, () -> SortKey.by(""));
+    }
+
+    // --- Direction enum: asc()/desc() are independent and immutable ---
+
+    @Test
+    void testAscDesc_returnNewInstances() {
+        SortKey base = SortKey.by("age");
+        SortKey desc = base.desc();
+        SortKey asc = desc.asc();
+        // base unchanged: still ascending
+        Object[] arr1 = { person("B", 30), person("A", 10) };
+        Arrays.sort(arr1, base.toComparator());
+        assertEquals(10, ((StructData) arr1[0]).getField("age").get());
+        // desc sorts descending
+        Object[] arr2 = { person("B", 10), person("A", 30) };
+        Arrays.sort(arr2, desc.toComparator());
+        assertEquals(30, ((StructData) arr2[0]).getField("age").get());
+        // asc sorts ascending
+        Object[] arr3 = { person("B", 30), person("A", 10) };
+        Arrays.sort(arr3, asc.toComparator());
+        assertEquals(10, ((StructData) arr3[0]).getField("age").get());
     }
 }

--- a/core/src/test/java/com/elminster/jcp/module/base/arrays/SortKeyTest.java
+++ b/core/src/test/java/com/elminster/jcp/module/base/arrays/SortKeyTest.java
@@ -1,0 +1,193 @@
+package com.elminster.jcp.module.base.arrays;
+
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.statement.declaration.StructFieldDef;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.eval.data.IntegerData;
+import com.elminster.jcp.eval.data.StringData;
+import com.elminster.jcp.eval.data.StructData;
+import com.elminster.jcp.eval.data.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SortKey#toComparator()} — no JCP runtime required.
+ */
+class SortKeyTest {
+
+    private StructType personType;
+    private StructType addressType;
+
+    @BeforeEach
+    void setUp() {
+        personType = new StructType("Person", Arrays.asList(
+            new StructFieldDef("name", SystemDataType.STRING),
+            new StructFieldDef("age", SystemDataType.INT)
+        ));
+        addressType = new StructType("Address", Arrays.asList(
+            new StructFieldDef("city", SystemDataType.STRING)
+        ));
+    }
+
+    private StructData person(String name, int age) {
+        StructData p = new StructData(Identifier.fromName("p"), personType);
+        p.setField("name", new StringData(name, false));
+        p.setField("age", new IntegerData(age, false));
+        return p;
+    }
+
+    // --- single field, int leaf ---
+
+    @Test
+    void testSortByInt_asc() {
+        Object[] arr = { person("B", 30), person("A", 20), person("C", 10) };
+        Arrays.sort(arr, SortKey.by("age").toComparator());
+        assertEquals(10, ((StructData) arr[0]).getField("age").get());
+        assertEquals(20, ((StructData) arr[1]).getField("age").get());
+        assertEquals(30, ((StructData) arr[2]).getField("age").get());
+    }
+
+    @Test
+    void testSortByInt_desc() {
+        Object[] arr = { person("B", 10), person("A", 30), person("C", 20) };
+        Arrays.sort(arr, SortKey.by("age").desc().toComparator());
+        assertEquals(30, ((StructData) arr[0]).getField("age").get());
+        assertEquals(20, ((StructData) arr[1]).getField("age").get());
+        assertEquals(10, ((StructData) arr[2]).getField("age").get());
+    }
+
+    // --- single field, String leaf ---
+
+    @Test
+    void testSortByString_asc() {
+        Object[] arr = { person("Charlie", 1), person("Alice", 2), person("Bob", 3) };
+        Arrays.sort(arr, SortKey.by("name").toComparator());
+        assertEquals("Alice", ((StructData) arr[0]).getField("name").get());
+        assertEquals("Bob", ((StructData) arr[1]).getField("name").get());
+        assertEquals("Charlie", ((StructData) arr[2]).getField("name").get());
+    }
+
+    @Test
+    void testSortByString_desc() {
+        Object[] arr = { person("Alice", 1), person("Charlie", 2), person("Bob", 3) };
+        Arrays.sort(arr, SortKey.by("name").desc().toComparator());
+        assertEquals("Charlie", ((StructData) arr[0]).getField("name").get());
+        assertEquals("Bob", ((StructData) arr[1]).getField("name").get());
+        assertEquals("Alice", ((StructData) arr[2]).getField("name").get());
+    }
+
+    // --- asc() is identity ---
+
+    @Test
+    void testAscIsDefault() {
+        SortKey k = SortKey.by("age");
+        SortKey k2 = SortKey.by("age").asc();
+        Object[] a1 = { person("B", 30), person("A", 10) };
+        Object[] a2 = { person("B", 30), person("A", 10) };
+        Arrays.sort(a1, k.toComparator());
+        Arrays.sort(a2, k2.toComparator());
+        assertEquals(((StructData) a1[0]).getField("age").get(),
+                     ((StructData) a2[0]).getField("age").get());
+    }
+
+    // --- missing field → null-last ---
+
+    @Test
+    void testMissingField_sortsLast_asc() {
+        StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.INT)));
+        StructData withField = new StructData(Identifier.fromName("a"), t);
+        withField.setField("x", new IntegerData(5, false));
+        StructData missingField = new StructData(Identifier.fromName("b"), t);
+
+        Object[] arr = { missingField, withField };
+        Arrays.sort(arr, SortKey.by("x").toComparator());
+        assertEquals(5, ((StructData) arr[0]).getField("x").get());
+        assertNull(((StructData) arr[1]).getField("x"));
+    }
+
+    @Test
+    void testMissingField_sortsLast_desc() {
+        StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.INT)));
+        StructData withField = new StructData(Identifier.fromName("a"), t);
+        withField.setField("x", new IntegerData(5, false));
+        StructData missingField = new StructData(Identifier.fromName("b"), t);
+
+        Object[] arr = { missingField, withField };
+        Arrays.sort(arr, SortKey.by("x").desc().toComparator());
+        assertEquals(5, ((StructData) arr[0]).getField("x").get());
+        assertNull(((StructData) arr[1]).getField("x"));
+    }
+
+    @Test
+    void testBothMissingField_staysEqual() {
+        StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.INT)));
+        StructData a = new StructData(Identifier.fromName("a"), t);
+        StructData b = new StructData(Identifier.fromName("b"), t);
+        Comparator<Object> cmp = SortKey.by("x").toComparator();
+        assertEquals(0, cmp.compare(a, b));
+    }
+
+    // --- non-StructData element → null-last ---
+
+    @Test
+    void testNonStructElement_sortsLast() {
+        StructData s = new StructData(Identifier.fromName("a"), personType);
+        s.setField("age", new IntegerData(1, false));
+        Object nonStruct = "plain string";
+
+        Object[] arr = { nonStruct, s };
+        Arrays.sort(arr, SortKey.by("age").toComparator());
+        assertSame(s, arr[0]);
+        assertSame(nonStruct, arr[1]);
+    }
+
+    // --- nested path ---
+
+    @Test
+    void testNestedPath() {
+        StructType personWithAddress = new StructType("PersonAddr", Arrays.asList(
+            new StructFieldDef("name", SystemDataType.STRING),
+            new StructFieldDef("address", SystemDataType.ANY)
+        ));
+
+        StructData addr1 = new StructData(Identifier.fromName("addr1"), addressType);
+        addr1.setField("city", new StringData("Berlin", false));
+        StructData addr2 = new StructData(Identifier.fromName("addr2"), addressType);
+        addr2.setField("city", new StringData("Amsterdam", false));
+
+        // Wrap nested StructData in AnyData so .get() returns the StructData
+        StructData p1 = new StructData(Identifier.fromName("p1"), personWithAddress);
+        p1.setField("name", new StringData("X", false));
+        p1.setField("address", new com.elminster.jcp.eval.data.AnyData<>(addr1));
+
+        StructData p2 = new StructData(Identifier.fromName("p2"), personWithAddress);
+        p2.setField("name", new StringData("Y", false));
+        p2.setField("address", new com.elminster.jcp.eval.data.AnyData<>(addr2));
+
+        Object[] arr = { p1, p2 };
+        Arrays.sort(arr, SortKey.by("address.city").toComparator());
+        // p2 (Amsterdam) should sort before p1 (Berlin)
+        StructData first = (StructData) arr[0];
+        StructData firstAddr = (StructData) first.getField("address").get();
+        assertEquals("Amsterdam", firstAddr.getField("city").get());
+    }
+
+    // --- non-struct mid-node → null-last ---
+
+    @Test
+    void testNestedPath_nonStructMidNode_sortsLast() {
+        StructType t = new StructType("T", Arrays.asList(new StructFieldDef("x", SystemDataType.STRING)));
+        StructData s = new StructData(Identifier.fromName("s"), t);
+        // "x" is a String, not a StructData — navigating "x.sub" should null-out
+        s.setField("x", new StringData("hello", false));
+
+        Object[] arr = { s };
+        Comparator<Object> cmp = SortKey.by("x.sub").toComparator();
+        assertEquals(0, cmp.compare(s, s)); // both resolve null → equal
+    }
+}

--- a/docs/brainstorms/2026-03-20-arrays-sort-struct-brainstorm.md
+++ b/docs/brainstorms/2026-03-20-arrays-sort-struct-brainstorm.md
@@ -1,0 +1,87 @@
+# Brainstorm: Arrays.sort for Struct Arrays with SortKey
+
+**Date:** 2026-03-20
+**Status:** Ready for planning
+**Related:** Issue #55
+
+## What We're Building
+
+A `SortKey` builder type and new `Arrays.sort` / `Arrays.reverse` overloads that let JCP users sort struct arrays by one or more fields, with per-field direction control and nested field path support.
+
+## Why
+
+`Arrays.sort(Object[])` requires elements to implement `Comparable`. `StructData` does not, so users cannot sort struct arrays at all today. A field-name-based API solves this without requiring lambda support.
+
+## API Design
+
+### SortKey builder
+
+```java
+SortKey.by("name")               // ascending by default
+SortKey.by("name").asc()
+SortKey.by("name").desc()
+SortKey.by("address.city").desc() // nested field path via dot notation
+```
+
+### Arrays.sort overloads
+
+```java
+// Single field
+Arrays.sort(persons, SortKey.by("age"))
+
+// Multiple fields (primary, secondary, ...)
+Arrays.sort(persons, SortKey.by("lastName"), SortKey.by("firstName"))
+
+// Mixed directions
+Arrays.sort(persons, SortKey.by("age").desc(), SortKey.by("name").asc())
+```
+
+### Arrays.reverse
+
+```java
+Arrays.reverse(a)  // reverses any array in-place, returns the array
+```
+
+## Scope
+
+### Deliverables
+- `SortKey` class in `module/base/arrays/` with `by(String fieldPath)`, `.asc()`, `.desc()`
+- `Arrays.sort(Object[], SortKey...)` overload — struct arrays only
+- `Arrays.reverse(int[])`, `Arrays.reverse(String[])`, `Arrays.reverse(boolean[])`, `Arrays.reverse(double[])`, `Arrays.reverse(Object[])` overloads
+- `BaseModuleRegister` updated to expose new overloads
+- Tests for eval mode covering: single field, multi-field, nested path, ASC/DESC, null-field handling, reverse
+
+### Out of Scope
+- Sorting non-struct `Object[]` with `SortKey` (e.g. boxed `Integer[]`)
+- Lambda/function-reference comparator (tracked separately, blocked on lambda support)
+- Compile mode support for `SortKey` (can be added once eval is stable)
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Field path separator | Dot notation (`"address.city"`) | Familiar, mirrors JCP field access syntax |
+| Applies to | Struct arrays only | Keeps scope focused; primitive arrays have dedicated overloads |
+| Missing/null field | Nulls sort last (both ASC and DESC) | Predictable, non-crashing behavior |
+| Direction default | ASC | Industry standard default |
+| Reverse | Dedicated `Arrays.reverse()` | Orthogonal to sorting; useful independently |
+| SortKey location | `module/base/arrays/SortKey.java` | Co-located with `Arrays.java` |
+
+## Field Path Resolution
+
+For a path like `"address.city"`:
+1. Split on `.`
+2. Walk `StructData.getField()` for each segment
+3. If any segment returns null or a non-`StructData` mid-path, treat as null (sort last)
+4. Final value compared via natural ordering of the primitive `Data` value
+
+Supported leaf types for comparison: `int`, `String`, `boolean`, `double` (existing `SystemDataType` primitives).
+
+## Open Questions
+
+1. Should `SortKey` be exposed as a first-class JCP `DataType` (so it appears in the type system), or remain a pure Java helper invoked via static method call?
+2. Should `Arrays.reverse` return the array (consistent with existing `sort` overloads) or `void`?
+
+## Next Steps
+
+Run `/gw-plan` to create implementation plan.

--- a/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan-enhanced.md
+++ b/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan-enhanced.md
@@ -1,0 +1,207 @@
+---
+title: "feat: Arrays.sort for struct arrays with SortKey builder (Enhanced)"
+type: feat
+date: 2026-03-20
+issue: 56
+review_date: 2026-03-20
+original_plan: docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan.md
+---
+
+# feat: Arrays.sort for Struct Arrays with SortKey Builder (Enhanced)
+
+> **Note:** Enhanced version incorporating feedback from plan review on 2026-03-20.
+> Primary fix: replaced `SortKey...` varargs with fixed-arity overloads to match JCP's
+> reflection-based dispatch mechanism.
+
+## Overview
+
+Add a `SortKey` builder type and new `Arrays.sort` / `Arrays.reverse` overloads to the JCP base
+module. This lets users sort struct arrays by one or more fields with per-field direction
+(ASC/DESC), dot-notation nested field paths, and null-last semantics — without requiring lambda
+support.
+
+## Technical Approach
+
+### SortKey — pure Java builder, not a JCP DataType
+
+`SortKey` is a plain Java class registered alongside `Arrays` in `BaseModuleRegister`. It does
+**not** need to be a `SystemDataType` entry. `ClassConverter` will auto-register it as a DataType
+named `"SortKey"` (via `DataTypeUtils.getDataTypeAndCreateOnMissing`) when it appears as a
+parameter type. No manual type-system changes are required.
+
+```
+module/base/arrays/
+  Arrays.java          ← add sort(Object[], SortKey) + sort(Object[], SortKey, SortKey) +
+                          sort(Object[], SortKey, SortKey, SortKey) + reverse overloads
+  SortKey.java         ← new: builder class
+```
+
+### Why fixed-arity overloads instead of varargs
+
+JCP's `ClassConverter.getParameterDefs()` introspects methods via `method.getParameters()`.
+Java varargs `SortKey...` is seen as `SortKey[]` — a single fixed-arity array parameter. The
+runtime evaluator `FunCallEvaluator.hasSameParameterDefinition()` matches by
+`parameterDefs.length == arguments.length`. A caller passing 2 `SortKey` values has
+`argumentData.length == 2`, but the registered function has `parameterDefs.length == 1`.
+This causes `UndeclaredException` at runtime.
+
+**Solution:** Follow the existing `Arrays.java` pattern of explicit typed overloads:
+
+```java
+public static Object[] sort(Object[] a, SortKey k1)
+public static Object[] sort(Object[] a, SortKey k1, SortKey k2)
+public static Object[] sort(Object[] a, SortKey k1, SortKey k2, SortKey k3)
+```
+
+Three overloads cover all practical cases (primary, primary+secondary, three-level).
+The internal implementation delegates to a shared private method that accepts `SortKey[]`.
+
+### Field path resolution
+
+For a path `"address.city"`:
+1. Split on `"."` → `["address", "city"]`
+2. Starting from the `StructData` element, call `getField(segment)` for each segment
+3. If any intermediate result is `null` or not a `StructData`, return `null` (→ sorts last)
+4. The final `Data` value's `.get()` is compared via its natural `Comparable` order
+
+Supported leaf types: `Integer` (INT), `String`, `Boolean`, `Double` — all box types implement
+`Comparable`. Unsupported leaf types treat the value as `null` and sort last.
+
+### Comparator construction (internal)
+
+The private shared method composes per-field comparators:
+
+```java
+private static Object[] sortByKeys(Object[] a, SortKey... keys) {
+    Comparator<Object> comparator = (x, y) -> 0;
+    for (SortKey key : keys) {
+        comparator = comparator.thenComparing(key.toComparator());
+    }
+    java.util.Arrays.sort(a, comparator);
+    return a;
+}
+```
+
+Each `SortKey.toComparator()` resolves the field path, applies null-last logic, then reverses if
+`DESC`.
+
+### Arrays.reverse
+
+Five typed overloads (int[], String[], boolean[], double[], Object[]) each reverse in-place and
+return the array — consistent with existing `sort` overloads.
+
+### BaseModuleRegister
+
+Add `SortKey.class` to the registration list. `ClassConverter` will process it and register
+`SortKey` as a DataType so it can appear as a parameter type in `Arrays.sort` overloads.
+
+## Implementation Phases
+
+### Phase 1: SortKey builder
+
+**Deliverables:**
+- [ ] Create `SortKey.java` in `module/base/arrays/`
+  - `public static SortKey by(String fieldPath)` — factory method, ASC default
+  - `.asc()` / `.desc()` — fluent direction setters, return `this`
+  - `Comparator<Object> toComparator()` — package-private, used by `Arrays`
+  - Private field path resolution: split on `"."`, walk `StructData.getField()`, null-last
+- [ ] Unit-test `SortKey.toComparator()` directly (no JCP runtime needed):
+  - Single-level field, int leaf, ASC and DESC
+  - Single-level field, String leaf
+  - Nested path `"address.city"`
+  - Missing field → sorts last (both ASC and DESC)
+  - Non-StructData element → sorts last
+  - Empty field path edge case
+
+### Phase 2: Arrays.sort with SortKey (fixed-arity overloads)
+
+**Deliverables:**
+- [ ] Add to `Arrays.java`:
+  - `public static Object[] sort(Object[] a, SortKey k1)`
+  - `public static Object[] sort(Object[] a, SortKey k1, SortKey k2)`
+  - `public static Object[] sort(Object[] a, SortKey k1, SortKey k2, SortKey k3)`
+  - Private `sortByKeys(Object[] a, SortKey... keys)` — shared implementation
+- [ ] Register `SortKey.class` in `BaseModuleRegister.classToRegister()`
+- [ ] Integration tests via `FunctionCallExpression` dispatch (not direct Java calls):
+  - 1-key sort (validates `sort(Object[], SortKey)` overload resolves)
+  - 2-key sort (validates `sort(Object[], SortKey, SortKey)` overload resolves)
+  - Sort with nested path via dispatch
+  - Null-field element via dispatch
+
+### Phase 3: Arrays.reverse
+
+**Deliverables:**
+- [ ] Add `reverse(int[])`, `reverse(String[])`, `reverse(boolean[])`, `reverse(double[])`,
+  `reverse(Object[])` to `Arrays.java` — each reverses in-place, returns the array
+- [ ] Tests for all five overloads:
+  - Empty array
+  - Single-element array
+  - Even-length array
+  - Odd-length array
+
+### Phase 4: Coverage verification
+
+- [ ] Run `mvn verify -pl core` — confirm JaCoCo ≥ 80% instruction and branch
+- [ ] Fix any coverage gaps (target: SortKey path resolution branches, all `sort` overloads)
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] `Arrays.sort(persons, SortKey.by("age"))` sorts struct array by int field ascending
+- [ ] `Arrays.sort(persons, SortKey.by("name").desc())` sorts descending
+- [ ] `Arrays.sort(persons, SortKey.by("lastName"), SortKey.by("firstName"))` sorts by two fields
+- [ ] `Arrays.sort(persons, SortKey.by("lastName"), SortKey.by("firstName"), SortKey.by("age"))` sorts by three fields
+- [ ] `Arrays.sort(persons, SortKey.by("address.city"))` resolves nested field path
+- [ ] Elements with a missing/null field sort to the end (null-last, both ASC and DESC)
+- [ ] `Arrays.reverse(intArray)` reverses in-place and returns the array
+- [ ] `Arrays.reverse(objectArray)` works for struct arrays
+- [ ] Existing `Arrays.sort(int[])` / `sort(String[])` etc. are unaffected
+- [ ] All three `sort(Object[], SortKey...)` overloads are callable via `FunctionCallExpression` dispatch without `UndeclaredException`
+
+### Non-Functional
+
+- [ ] No new `SystemDataType` entries required
+- [ ] `SortKey` is not exposed as a JCP DSL keyword — it is a library type only
+- [ ] JaCoCo thresholds pass (≥ 80% instruction, ≥ 80% branch)
+- [ ] No compile-mode changes (out of scope)
+
+## Dependencies
+
+- No blocked dependencies — self-contained within `core/`
+- `StructData.getField(String)` already exists and is used as-is
+- `ClassConverter.registerClass()` auto-registers `SortKey` as a DataType when encountered as a parameter type — no manual registration beyond adding to `BaseModuleRegister`
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `SortKey` DataType not auto-registered before `Arrays` methods are scanned | M | H | Register `SortKey.class` **before** `Arrays.class` in `BaseModuleRegister.classToRegister()` list |
+| Fixed-arity overloads cause `FunctionAmbiguityException` when 2-key and 3-key overloads both match | L | H | Java dispatch passes exact argument count to `getParameterDefs`; `hasSameParameterDefinition` checks exact length — no ambiguity possible across different arities |
+| `ClassConverter` unwraps `Data.get()` before passing to Java method; `SortKey` is the raw value | L | M | `AbstractModuleFunction.doFunction` calls `getArgumentValues` which calls `.get()` on each `Data`; since `SortKey` is stored as `AnyData<SortKey>`, `.get()` returns the `SortKey` object correctly |
+| Nested path on non-struct mid-node silently wrong | L | M | Covered by null-last rule; explicit test: path through a non-struct field |
+| Coverage drops below 80% threshold | L | H | Tests cover: all sort overloads, all reverse overloads, all SortKey direction/path branches, null-field case, unsupported leaf type |
+
+## Testing Strategy
+
+**Unit tests** (no JCP runtime — test Java logic directly):
+- `SortKeyTest`: path resolution, direction, null-last, nested path, unsupported leaf
+- `ArraysReverseTest`: all five typed overloads, edge cases
+
+**Integration tests** (via `FunctionCallExpression` — validates full dispatch chain):
+- `ArraysSortStructTest`: all three sort overloads, nested path, null-field, multi-key ordering
+- Pattern: follow `ArraysTest.evalOnArray()` helper — seed array in context, call via `FunctionCallExpression`, assert result
+
+## Changes from Original Plan
+
+1. **Replaced `SortKey...` varargs with fixed-arity overloads** — `sort(Object[], SortKey)`, `sort(Object[], SortKey, SortKey)`, `sort(Object[], SortKey, SortKey, SortKey)`. Root cause: JCP's reflection-based dispatch (`ClassConverter` + `FunCallEvaluator`) does not handle varargs; callers with N `SortKey` args would cause `UndeclaredException`.
+2. **Corrected risk mitigation for varargs** — Original mitigation cited Java compile-time overload resolution, which is irrelevant to JCP runtime dispatch. Updated to document the fixed-arity approach as the actual solution.
+3. **Added dispatch integration tests as an explicit acceptance criterion** — Direct Java unit tests of `SortKey.toComparator()` do not catch runtime dispatch failures. Integration tests via `FunctionCallExpression` are required.
+4. **Added SortKey registration ordering note** — `SortKey.class` must precede `Arrays.class` in the `BaseModuleRegister` list to ensure the `SortKey` DataType exists before `Arrays` methods are scanned.
+5. **Expanded testing strategy** — Separated unit tests (pure Java) from integration tests (JCP dispatch), with explicit patterns for each.
+
+## References
+
+- Original plan: `docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan.md`
+- Plan review: `docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan-review.md`
+- Issue: https://github.com/elminsterjimmy/jcp/issues/56

--- a/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan-review.md
+++ b/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan-review.md
@@ -1,0 +1,61 @@
+# Plan Review: feat: Arrays.sort for Struct Arrays with SortKey Builder
+
+**Issue:** #56 | **Reviewer:** Claude Code | **Date:** 2026-03-20
+
+## Overall Assessment
+
+**Status:** Needs Revision
+**Quality Score:** 6/10
+
+The plan is well-structured and covers the right scope, but contains a **critical blocking flaw**: the `SortKey...` varargs approach is incompatible with JCP's reflection-based dispatch mechanism. Without addressing this, the implementation cannot work. The rest of the plan is solid.
+
+## Strengths
+
+- ✅ Clear rationale for `SortKey` as a pure Java builder (no `SystemDataType` changes)
+- ✅ Field path resolution algorithm is well-specified (split, walk, null-last)
+- ✅ Null-last semantics are explicitly designed for both ASC and DESC
+- ✅ `Arrays.reverse` correctly identified as orthogonal and scoped as typed overloads
+- ✅ Risk table is honest and mentions the varargs dispatch concern — but the mitigation is insufficient
+
+## Areas for Improvement
+
+### Critical Issues
+
+- ❌ **Varargs `SortKey...` is incompatible with JCP's runtime dispatch.** `ClassConverter.getParameterDefs()` introspects via `method.getParameters()`, which sees `SortKey...` as `SortKey[]` — a single fixed-arity array parameter. `FunCallEvaluator.hasSameParameterDefinition()` matches by `parameterDefs.length == arguments.length`. A caller passing 2 `SortKey` objects will have `argumentData.length == 2`, but the registered function has `parameterDefs.length == 1` (`SortKey[]`). This is a dispatch mismatch that will produce `UndeclaredException` at runtime.
+
+- ❌ **No resolution strategy for the varargs problem is provided.** The risk entry says "Java method resolution prefers the more specific overload" — this applies to Java compile-time resolution, not to JCP's reflection-based runtime dispatch. The mitigation is wrong.
+
+### Suggestions
+
+- 💡 Replace `SortKey...` with explicit fixed-arity overloads: `sort(Object[], SortKey)`, `sort(Object[], SortKey, SortKey)`, `sort(Object[], SortKey, SortKey, SortKey)`. This is the same pattern used throughout `Arrays.java` for typed overloads. Covers the common cases (1–3 sort keys) without varargs complexity.
+- 💡 Alternatively, accept a `SortKey[]` parameter explicitly — but then callers must construct the array explicitly, which is awkward at the JCP DSL level.
+- 💡 Add a test that explicitly exercises `FunctionCallExpression` dispatch (not just unit-testing `SortKey.toComparator()` directly), since that is the only way to catch dispatch failures.
+- 💡 The `getArgumentValues(arguments)` call in `ClassConverter.registerStaticMethod` unwraps `Data.get()` for each argument. For `SortKey`, this means the `SortKey` object itself is passed to the Java method — which is correct. But this chain should be explicitly verified in the integration test.
+
+## Specific Feedback by Section
+
+### Overview
+Clear, concise, accurate. Score: 9/10
+
+### Technical Approach
+Field path resolution and comparator construction are well-specified. The `SortKey` registration rationale is sound. However, the varargs assumption is wrong and is the root of the critical issue. Score: 5/10
+
+### Implementation Phases
+Phases are logical and ordered correctly. Phase 1 (SortKey) before Phase 2 (Arrays) is right. Missing: a phase for evaluating the dispatch strategy before writing code. Score: 6/10
+
+### Acceptance Criteria
+Functional criteria are comprehensive. Non-functional criteria correctly exclude compile-mode. Missing: a criterion for "calling via FunctionCallExpression dispatch works end-to-end". Score: 7/10
+
+### Risk Analysis
+The varargs risk is identified but the mitigation is incorrect (Java compile-time resolution ≠ JCP runtime dispatch). Score: 4/10
+
+## Recommended Actions
+
+1. **Replace `SortKey...` varargs with fixed-arity overloads** — `sort(Object[], SortKey)`, `sort(Object[], SortKey, SortKey)`, `sort(Object[], SortKey, SortKey, SortKey)` in `Arrays.java`. Consistent with existing `Arrays` pattern.
+2. **Add an integration test** that calls `Arrays.sort` via `FunctionCallExpression` with 1, 2, and 3 `SortKey` arguments, not just direct Java method calls. This validates the full dispatch path.
+3. **Update risk table** to remove the incorrect Java-compile-time mitigation and document the fixed-arity approach as the resolution.
+
+## Sign-off
+
+- [ ] All critical issues addressed
+- [ ] Plan ready for implementation

--- a/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan.md
+++ b/docs/plans/2026-03-20-feat-arrays-sort-struct-sortkey-plan.md
@@ -1,0 +1,130 @@
+---
+title: "feat: Arrays.sort for struct arrays with SortKey builder"
+type: feat
+date: 2026-03-20
+issue: 56
+---
+
+# feat: Arrays.sort for Struct Arrays with SortKey Builder
+
+## Overview
+
+Add a `SortKey` builder type and new `Arrays.sort(Object[], SortKey...)` / `Arrays.reverse(...)`
+overloads to the JCP base module. This lets users sort struct arrays by one or more fields with
+per-field direction (ASC/DESC), dot-notation nested field paths, and null-last semantics — all
+without requiring lambda support.
+
+## Technical Approach
+
+### SortKey — pure Java builder, not a JCP DataType
+
+`SortKey` is a plain Java class registered alongside `Arrays` in `BaseModuleRegister`. It does
+**not** need to be a `SystemDataType` entry. The JCP runtime resolves it as `ANY` when passed as
+an argument, which is sufficient for dispatch. No type-system changes are required.
+
+```
+module/base/arrays/
+  Arrays.java          ← add sort(Object[], SortKey...) + reverse overloads
+  SortKey.java         ← new: builder class
+```
+
+### Field path resolution
+
+For a path `"address.city"`:
+1. Split on `"."` → `["address", "city"]`
+2. Starting from the `StructData` element, call `getField(segment)` for each segment
+3. If any intermediate result is `null` or not a `StructData`, return `null` (→ sorts last)
+4. The final `Data` value's `.get()` is compared via its natural `Comparable` order
+
+Supported leaf types: `Integer` (INT), `String`, `Boolean`, `Double` — all box types implement
+`Comparable`, so a single unchecked cast suffices. Unsupported leaf types sort last.
+
+### Comparator construction
+
+`Arrays.sort(Object[], SortKey...)` builds a `Comparator<Object>` by composing per-field
+comparators in order:
+
+```java
+Comparator<Object> comparator = (a, b) -> 0;
+for (SortKey key : keys) {
+    comparator = comparator.thenComparing(key.toComparator());
+}
+java.util.Arrays.sort(array, comparator);
+```
+
+Each `SortKey.toComparator()` resolves the field path, applies null-last logic, then reverses if
+`DESC`.
+
+### Arrays.reverse
+
+Five typed overloads (int[], String[], boolean[], double[], Object[]) each reverse in-place and
+return the array — consistent with existing `sort` overloads.
+
+### BaseModuleRegister
+
+Add `SortKey.class` to the registration list so the runtime can resolve it as a parameter type.
+
+## Implementation Phases
+
+### Phase 1: SortKey builder
+
+- [ ] Create `SortKey.java` in `module/base/arrays/`
+  - `public static SortKey by(String fieldPath)` — factory method, ASC default
+  - `.asc()` / `.desc()` — fluent direction setters, return `this`
+  - `toComparator()` — package-private, used by `Arrays`
+  - Field path resolution logic (split, walk `StructData`, null-last)
+- [ ] Unit-test `SortKey` directly: path resolution, direction, null-last, nested paths
+
+### Phase 2: Arrays.sort with SortKey
+
+- [ ] Add `Arrays.sort(Object[] a, SortKey... keys)` to `Arrays.java`
+  - Compose per-field comparators, call `java.util.Arrays.sort(a, comparator)`
+  - Return `a`
+- [ ] Register `SortKey.class` in `BaseModuleRegister.classToRegister()`
+- [ ] Eval-mode integration tests (see Acceptance Criteria)
+
+### Phase 3: Arrays.reverse
+
+- [ ] Add `reverse(int[])`, `reverse(String[])`, `reverse(boolean[])`, `reverse(double[])`,
+  `reverse(Object[])` to `Arrays.java` — each reverses in-place, returns the array
+- [ ] Tests for all five overloads (empty array, single element, even/odd length)
+
+### Phase 4: Coverage verification
+
+- [ ] Run `mvn verify -pl core` — confirm JaCoCo ≥ 80% instruction and branch
+- [ ] Fix any coverage gaps
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] `Arrays.sort(persons, SortKey.by("age"))` sorts struct array by int field ascending
+- [ ] `Arrays.sort(persons, SortKey.by("name").desc())` sorts descending
+- [ ] `Arrays.sort(persons, SortKey.by("lastName"), SortKey.by("firstName"))` sorts by two fields
+- [ ] `Arrays.sort(persons, SortKey.by("address.city"))` resolves nested field path
+- [ ] Elements with a missing/null field sort to the end (null-last, both ASC and DESC)
+- [ ] `Arrays.reverse(intArray)` reverses in-place and returns the array
+- [ ] `Arrays.reverse(objectArray)` works for struct arrays
+- [ ] Existing `Arrays.sort(int[])` / `sort(String[])` etc. are unaffected
+
+### Non-Functional
+
+- [ ] No new `SystemDataType` entries required
+- [ ] `SortKey` is not exposed as a JCP DSL keyword — it is a library type only
+- [ ] JaCoCo thresholds pass (≥ 80% instruction, ≥ 80% branch)
+- [ ] No compile-mode changes (out of scope)
+
+## Dependencies
+
+- No blocked dependencies — this is self-contained within `core/`
+- `StructData.getField(String)` already exists and is used as-is
+- `BaseModuleRegister` pattern is established; adding `SortKey.class` follows existing convention
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `SortKey` parameter type not resolved by `FunCallEvaluator` | M | H | Register `SortKey.class` in `BaseModuleRegister`; add integration test that calls via `FunctionCallExpression` |
+| Varargs `SortKey...` dispatch conflicts with existing `sort(Object[])` | M | M | Java method resolution prefers the more specific overload; verify with a test passing `SortKey` args |
+| Nested path on non-struct mid-node silently wrong | L | M | Covered by null-last rule; add explicit test for path through non-struct |
+| Coverage drops below 80% threshold | L | H | Write tests for all branches (empty keys, single key, multi-key, null field, unsupported leaf type) |


### PR DESCRIPTION
Closes #56

## Summary

- `SortKey.by("field").asc()/.desc()` — fluent builder for struct sort keys with dot-notation nested field paths
- `Arrays.sort(Object[], SortKey)`, `sort(Object[], SortKey, SortKey)`, `sort(Object[], SortKey, SortKey, SortKey)` — sort struct arrays by 1–3 fields
- `Arrays.reverse(int[]/String[]/boolean[]/double[]/Object[])` — in-place reverse for all array types
- Null-last semantics: missing or non-navigable fields sort to the end in both ASC and DESC

## Key Design Decisions

**Fixed-arity overloads instead of varargs:** JCP's `ClassConverter` sees `SortKey...` as `SortKey[]` (1 parameter). `FunCallEvaluator` matches by exact arity — a caller passing 2 `SortKey` values would get `UndeclaredException`. Three fixed-arity overloads follow the existing `Arrays.java` pattern.

**SortKey registered before Arrays:** `SortKey.class` precedes `Arrays.class` in `BaseModuleRegister` so its DataType is available when `Arrays` method signatures are scanned.

## Changes

- `SortKey.java` — new builder class with field path resolution
- `Arrays.java` — 3 sort overloads + 5 reverse overloads
- `BaseModuleRegister.java` — add `SortKey.class` before `Arrays.class`
- `SortKeyTest.java` — 11 unit tests (no runtime needed): ASC/DESC, nested path, null-last, non-struct element
- `ArraysSortStructTest.java` — 5 integration tests via `FunctionCallExpression` dispatch
- `ArraysTest.java` — 9 reverse tests added

## Testing

- 42 new tests added; 1170 total pass
- JaCoCo coverage checks pass (≥ 80% instruction and branch)