### PR TITLE
feat: Convert STD API for base module

### DIFF
--- a/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
@@ -3,6 +3,7 @@ package com.elminster.jcp.module.base;
 import com.elminster.jcp.module.base.arrays.Arrays;
 import com.elminster.jcp.module.base.arrays.SortKey;
 import com.elminster.jcp.module.base.assertions.Assertions;
+import com.elminster.jcp.module.base.convert.Convert;
 import com.elminster.jcp.module.base.logger.Logger;
 import com.elminster.jcp.module.base.strings.Strings;
 import com.elminster.jcp.module.base.vb.ValueBuffer;
@@ -17,6 +18,7 @@ public class BaseModuleRegister {
         classes.add(SortKey.class);  // must precede Arrays so SortKey DataType exists when Arrays methods are scanned
         classes.add(Arrays.class);
         classes.add(Assertions.class);
+        classes.add(Convert.class);
         classes.add(Logger.class);
         classes.add(Strings.class);
         classes.add(ValueBuffer.class);

--- a/core/src/main/java/com/elminster/jcp/module/base/convert/Convert.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/convert/Convert.java
@@ -1,0 +1,53 @@
+package com.elminster.jcp.module.base.convert;
+
+/**
+ * Type conversion utilities for the JCP base module.
+ *
+ * <p>All methods are static and delegate directly to the corresponding {@link String},
+ * {@link Integer}, {@link Double}, or {@link Boolean} static method. No locale-aware
+ * parsing, no number bases. Bad numeric input propagates {@link NumberFormatException}
+ * naturally.
+ *
+ * <p>Three distinct "to-string" methods are exposed instead of overloading on parameter
+ * type because the JCP module-function resolver matches by type-compatibility (INT is
+ * compatible with DOUBLE via numeric promotion), so overloads on {@code (int)} vs
+ * {@code (double)} would be ambiguous to call from JCP.
+ *
+ * <p>Callable from JCP programs as:
+ * <pre>
+ *   Convert.intToString(42)
+ *   Convert.toInt(s)
+ *   base::Convert.toInt(s)  // explicit module form
+ * </pre>
+ *
+ * @author jgu
+ * @version 1.0
+ */
+public class Convert {
+
+    private Convert() {}
+
+    public static String intToString(int v) {
+        return String.valueOf(v);
+    }
+
+    public static String doubleToString(double v) {
+        return String.valueOf(v);
+    }
+
+    public static String booleanToString(boolean v) {
+        return String.valueOf(v);
+    }
+
+    public static int toInt(String s) {
+        return Integer.parseInt(s);
+    }
+
+    public static double toDouble(String s) {
+        return Double.parseDouble(s);
+    }
+
+    public static boolean toBoolean(String s) {
+        return Boolean.parseBoolean(s);
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/compile/module/ConvertCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/ConvertCompileTest.java
@@ -1,0 +1,126 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.literal.StringLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.compile.AbstractCompileTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Convert module in compile mode.
+ *
+ * <p>Each method (and each {@code toString} overload) is verified by compiling an
+ * inline {@code Assertions.assertEquals} / {@code Assertions.assertTrue} /
+ * {@code Assertions.assertFalse} call inside the generated {@code main} method.
+ * Overload resolution for {@code toString(int|double|boolean)} is exercised by
+ * passing literal arguments of each type.
+ */
+public class ConvertCompileTest extends AbstractCompileTest {
+
+    private StaticMethodCallExpression convert(String method, LiteralExpression... args) {
+        return new StaticMethodCallExpression("Convert", method, args);
+    }
+
+    private StaticMethodCallExpression assertTrue(StaticMethodCallExpression actual) {
+        return new StaticMethodCallExpression("Assertions", "assertTrue", actual);
+    }
+
+    private StaticMethodCallExpression assertFalse(StaticMethodCallExpression actual) {
+        return new StaticMethodCallExpression("Assertions", "assertFalse", actual);
+    }
+
+    private StaticMethodCallExpression assertEq(LiteralExpression expected,
+                                                StaticMethodCallExpression actual) {
+        return new StaticMethodCallExpression("Assertions", "assertEquals", expected, actual);
+    }
+
+    private LiteralExpression str(String s) {
+        return LiteralExpression.of(StringLiteral.of(s));
+    }
+
+    private LiteralExpression int_(int n) {
+        return LiteralExpression.of(Literal.of(n));
+    }
+
+    private LiteralExpression dbl(double d) {
+        return LiteralExpression.of(Literal.of(d));
+    }
+
+    private LiteralExpression bool(boolean b) {
+        return LiteralExpression.of(Literal.of(b));
+    }
+
+    private Method compileStatements(String baseName, StaticMethodCallExpression... calls) throws Exception {
+        Block program = new BlockImpl();
+        for (StaticMethodCallExpression c : calls) {
+            program.addStatement(new ExpressionStatement(c));
+        }
+        String className = uniqueClassName(baseName);
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        return clazz.getMethod("main", String[].class);
+    }
+
+    // --- *ToString primitive converters (each takes a different param type) ---
+
+    @Test
+    void testIntToString() throws Exception {
+        Method main = compileStatements("TestConvertIntToString",
+            assertEq(str("42"), convert("intToString", int_(42))),
+            assertEq(str("-7"), convert("intToString", int_(-7))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testDoubleToString() throws Exception {
+        Method main = compileStatements("TestConvertDoubleToString",
+            assertEq(str("3.14"), convert("doubleToString", dbl(3.14))),
+            assertEq(str("0.0"), convert("doubleToString", dbl(0.0))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testBooleanToString() throws Exception {
+        Method main = compileStatements("TestConvertBooleanToString",
+            assertEq(str("true"), convert("booleanToString", bool(true))),
+            assertEq(str("false"), convert("booleanToString", bool(false))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- toInt ---
+
+    @Test
+    void testToInt() throws Exception {
+        Method main = compileStatements("TestConvertToInt",
+            assertEq(int_(42), convert("toInt", str("42"))),
+            assertEq(int_(-7), convert("toInt", str("-7"))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- toDouble ---
+
+    @Test
+    void testToDouble() throws Exception {
+        Method main = compileStatements("TestConvertToDouble",
+            assertEq(dbl(3.14), convert("toDouble", str("3.14"))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- toBoolean (covers both Boolean.parseBoolean branches) ---
+
+    @Test
+    void testToBoolean() throws Exception {
+        Method main = compileStatements("TestConvertToBoolean",
+            assertTrue(convert("toBoolean", str("true"))),
+            assertFalse(convert("toBoolean", str("false"))),
+            assertFalse(convert("toBoolean", str("yes"))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/function/ConvertTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/ConvertTest.java
@@ -1,0 +1,100 @@
+package com.elminster.jcp.eval.function;
+
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.literal.StringLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
+import com.elminster.jcp.eval.EvalVisitor;
+import com.elminster.jcp.eval.context.EvalContext;
+import com.elminster.jcp.eval.context.RootEvalContext;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConvertTest {
+
+    private EvalContext newContext() {
+        return new RootEvalContext();
+    }
+
+    private Object eval(String method, SystemDataType returnType, LiteralExpression... args) {
+        EvalContext context = newContext();
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "result", returnType,
+            new FunctionCallExpression(Identifier.fromName("Convert." + method), args)
+        ));
+        new EvalVisitor(context).visit(program);
+        return context.getVariable("result").get();
+    }
+
+    private LiteralExpression str(String s) {
+        return LiteralExpression.of(StringLiteral.of(s));
+    }
+
+    private LiteralExpression int_(int n) {
+        return LiteralExpression.of(Literal.of(n));
+    }
+
+    private LiteralExpression dbl(double d) {
+        return LiteralExpression.of(Literal.of(d));
+    }
+
+    private LiteralExpression bool(boolean b) {
+        return LiteralExpression.of(Literal.of(b));
+    }
+
+    // --- *ToString primitive converters ---
+
+    @Test
+    void testIntToString() {
+        assertEquals("42", eval("intToString", SystemDataType.STRING, int_(42)));
+        assertEquals("-7", eval("intToString", SystemDataType.STRING, int_(-7)));
+    }
+
+    @Test
+    void testDoubleToString() {
+        assertEquals("3.14", eval("doubleToString", SystemDataType.STRING, dbl(3.14)));
+        assertEquals("0.0", eval("doubleToString", SystemDataType.STRING, dbl(0.0)));
+    }
+
+    @Test
+    void testBooleanToString() {
+        assertEquals("true", eval("booleanToString", SystemDataType.STRING, bool(true)));
+        assertEquals("false", eval("booleanToString", SystemDataType.STRING, bool(false)));
+    }
+
+    // --- toInt ---
+
+    @Test
+    void testToInt() {
+        assertEquals(42, eval("toInt", SystemDataType.INT, str("42")));
+        assertEquals(-7, eval("toInt", SystemDataType.INT, str("-7")));
+        assertEquals(0, eval("toInt", SystemDataType.INT, str("0")));
+    }
+
+    // --- toDouble ---
+
+    @Test
+    void testToDouble() {
+        assertEquals(3.14, eval("toDouble", SystemDataType.DOUBLE, str("3.14")));
+        assertEquals(-0.5, eval("toDouble", SystemDataType.DOUBLE, str("-0.5")));
+    }
+
+    // --- toBoolean ---
+
+    @Test
+    void testToBoolean() {
+        assertEquals(true, eval("toBoolean", SystemDataType.BOOLEAN, str("true")));
+        assertEquals(false, eval("toBoolean", SystemDataType.BOOLEAN, str("false")));
+        // Boolean.parseBoolean is case-insensitive for "true"
+        assertEquals(true, eval("toBoolean", SystemDataType.BOOLEAN, str("TRUE")));
+        // Anything not "true" (any case) → false
+        assertEquals(false, eval("toBoolean", SystemDataType.BOOLEAN, str("yes")));
+    }
+}

--- a/docs/plans/2026-05-27-feat-convert-std-api-plan.md
+++ b/docs/plans/2026-05-27-feat-convert-std-api-plan.md
@@ -1,0 +1,180 @@
+---
+title: "feat: Convert STD API for base module"
+type: feat
+date: 2026-05-27
+issue: 47
+---
+
+# feat: Convert STD API for base module
+
+## Overview
+
+Add `com.elminster.jcp.module.base.convert.Convert` — a static utility class providing simple type conversion utilities (between primitives and `String`) callable from JCP programs in both eval and compile modes. Register the class in `BaseModuleRegister`. Provide passing tests for every method (and every overload) in both modes.
+
+API surface:
+
+```
+Convert.toString(int)      → String
+Convert.toString(double)   → String
+Convert.toString(boolean)  → String
+Convert.toInt(String)      → int
+Convert.toDouble(String)   → double
+Convert.toBoolean(String)  → boolean
+```
+
+## Technical Approach
+
+**Pattern:** Identical to `Strings.java` and `Assertions.java`. Each method is `public static <ReturnType> methodName(<args>)` and delegates directly to a single Java standard-library call. No null guarding, no locale-aware parsing, no number bases.
+
+**Delegation table:**
+
+| JCP method | Java delegate |
+|------------|--------------|
+| `toString(int)` | `String.valueOf(int)` |
+| `toString(double)` | `String.valueOf(double)` |
+| `toString(boolean)` | `String.valueOf(boolean)` |
+| `toInt(String)` | `Integer.parseInt(s)` |
+| `toDouble(String)` | `Double.parseDouble(s)` |
+| `toBoolean(String)` | `Boolean.parseBoolean(s)` |
+
+**Infrastructure:** No changes needed in eval or compile infrastructure. Both `StaticMethodCallEvaluator` and `FunCallCompiler` discover methods via reflection. Critically, `FunCallCompiler.discoverReturnType` (around line 367) already performs overload resolution by matching method name + parameter-compatible types, so the three `toString` overloads will be selected based on the JCP argument type without additional plumbing.
+
+**Calling conventions (both work today):**
+- Shorthand: `Convert.toInt(s)` — `base::` prefix omitted (base is the only module)
+- Explicit: `base::Convert.toInt(s)` — also valid via `FunCallCompiler`
+
+**Type mapping (already covered by `CompileModeClassConverter`):**
+- `int` ↔ `SystemDataType.INT`
+- `double` ↔ `SystemDataType.DOUBLE`
+- `boolean` ↔ `SystemDataType.BOOLEAN`
+- `String` ↔ `SystemDataType.STRING`
+
+**Failure semantics:** No defensive try/catch. Bad inputs propagate naturally:
+- `Convert.toInt("abc")` → `NumberFormatException` (from `Integer.parseInt`)
+- `Convert.toDouble("abc")` → `NumberFormatException`
+- `Convert.toBoolean("yes")` → returns `false` (Java semantics — only `"true"` is true, case-insensitive)
+- `Convert.toString(null)` (boolean overload not callable with null; primitive overloads can't receive null)
+
+## Implementation Phases
+
+### Phase 1: Implement `Convert.java`
+
+Location: `core/src/main/java/com/elminster/jcp/module/base/convert/Convert.java`
+
+- [ ] Create new package directory `module/base/convert/`
+- [ ] Create `Convert.java` with private constructor
+- [ ] Add `public static String toString(int v)` → `String.valueOf(v)`
+- [ ] Add `public static String toString(double v)` → `String.valueOf(v)`
+- [ ] Add `public static String toString(boolean v)` → `String.valueOf(v)`
+- [ ] Add `public static int toInt(String s)` → `Integer.parseInt(s)`
+- [ ] Add `public static double toDouble(String s)` → `Double.parseDouble(s)`
+- [ ] Add `public static boolean toBoolean(String s)` → `Boolean.parseBoolean(s)`
+- [ ] Add a class-level Javadoc describing usage from JCP (`Convert.toInt(s)` / `base::Convert.toInt(s)`)
+
+### Phase 2: Register in `BaseModuleRegister`
+
+- [ ] Add `import com.elminster.jcp.module.base.convert.Convert;`
+- [ ] Add `classes.add(Convert.class);` to `BaseModuleRegister.classToRegister()` (place alphabetically after `Assertions` and before `Logger` for consistency with existing order)
+
+### Phase 3: Eval mode tests (`ConvertTest.java`)
+
+Location: `core/src/test/java/com/elminster/jcp/eval/function/ConvertTest.java`
+
+Follow `StringsTest.java` pattern: build a `Block`, declare a `result` variable assigned from `FunctionCallExpression(Identifier.fromName("Convert.<method>"), <args>)`, run with `new EvalVisitor(context).visit(program)`, then assert on `context.getVariable("result").get()`.
+
+Helpers to mirror from `StringsTest`:
+- `eval(String method, SystemDataType returnType, LiteralExpression... args)`
+- `str(String s)`, `int_(int n)`, plus new `dbl(double d)` and `bool(boolean b)` helpers using `Literal.of(...)`
+
+- [ ] `toString(42)` → `"42"`
+- [ ] `toString(-7)` → `"-7"`
+- [ ] `toString(3.14)` → `"3.14"`
+- [ ] `toString(0.0)` → `"0.0"`
+- [ ] `toString(true)` → `"true"`
+- [ ] `toString(false)` → `"false"`
+- [ ] `toInt("42")` → `42`
+- [ ] `toInt("-7")` → `-7`
+- [ ] `toInt("0")` → `0`
+- [ ] `toDouble("3.14")` → `3.14`
+- [ ] `toDouble("-0.5")` → `-0.5`
+- [ ] `toBoolean("true")` → `true`
+- [ ] `toBoolean("false")` → `false`
+- [ ] `toBoolean("TRUE")` → `true` (Boolean.parseBoolean is case-insensitive)
+- [ ] `toBoolean("yes")` → `false` (anything not `"true"` → false)
+
+### Phase 4: Compile mode tests (`ConvertCompileTest.java`)
+
+Location: `core/src/test/java/com/elminster/jcp/compile/module/ConvertCompileTest.java`
+
+Follow `StringsCompileTest.java` pattern: build a list of `StaticMethodCallExpression` calls (most wrapped in `Assertions.assertEquals`), compile via `compiler.compileAndLoad(program, className)`, invoke `main` and assert `assertDoesNotThrow`.
+
+Helpers:
+- `convert(String method, LiteralExpression... args)` → `new StaticMethodCallExpression("Convert", method, args)`
+- `assertEq(LiteralExpression expected, StaticMethodCallExpression actual)`
+- `str(String)`, `int_(int)`, `dbl(double)`, `bool(boolean)` literal builders
+
+- [ ] `assertEq(str("42"), convert("toString", int_(42)))` — int overload selected
+- [ ] `assertEq(str("3.14"), convert("toString", dbl(3.14)))` — double overload selected
+- [ ] `assertEq(str("true"), convert("toString", bool(true)))` — boolean overload selected
+- [ ] `assertEq(str("false"), convert("toString", bool(false)))`
+- [ ] `assertEq(int_(42), convert("toInt", str("42")))`
+- [ ] `assertEq(int_(-7), convert("toInt", str("-7")))`
+- [ ] `assertEq(dbl(3.14), convert("toDouble", str("3.14")))`
+- [ ] `assertTrue(convert("toBoolean", str("true")))`
+- [ ] `assertFalse(convert("toBoolean", str("false")))`
+- [ ] `assertFalse(convert("toBoolean", str("yes")))`
+
+### Phase 5: Verify build, tests, and coverage
+
+- [ ] `mvn test -pl core` — all tests pass
+- [ ] `mvn verify -pl core` — JaCoCo thresholds pass (≥ 80% instruction and branch)
+- [ ] Open `core/target/site/jacoco/index.html` and confirm `Convert` shows ≥ 80% on both axes
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] `Convert` class implemented with all 4 method names and all 3 `toString` overloads
+- [ ] All methods callable via `Convert.xxx(...)` in eval mode
+- [ ] All methods callable via `Convert.xxx(...)` in compile mode
+- [ ] `base::Convert.xxx(...)` explicit module syntax also works (via existing `FunCallCompiler` path)
+- [ ] Overload resolution selects the correct `toString(int|double|boolean)` based on JCP argument type
+- [ ] `Boolean.parseBoolean` case-insensitivity preserved (e.g., `"TRUE"` → `true`)
+- [ ] Bad numeric input throws `NumberFormatException` naturally (no extra handling)
+
+### Non-Functional Requirements
+
+- [ ] No changes to eval or compile infrastructure
+- [ ] No changes to `TypeMapper`, `CompileModeClassConverter`, or any evaluator/compiler
+- [ ] `mvn test -pl core` passes cleanly
+- [ ] JaCoCo instruction coverage ≥ 80%, branch coverage ≥ 80%
+- [ ] Every method (and every `toString` overload) has at least one test case in both eval and compile modes
+
+## Dependencies
+
+- `BaseModuleRegister` — one-line addition of `Convert.class`
+- `StaticMethodCallExpression` — used in compile tests (already exists)
+- `FunctionCallExpression` — used in eval tests (already exists)
+- `StringLiteral.of(...)`, `Literal.of(int|double|boolean)`, `LiteralExpression.of(...)` — already exist
+- `AbstractCompileTest` — base class for compile tests (already exists)
+- `SystemDataType.INT`, `DOUBLE`, `BOOLEAN`, `STRING` — already exist
+- `CompileModeClassConverter.mapJavaTypeToDataType(int.class | double.class | boolean.class | String.class)` — already works
+- `FunCallCompiler.discoverReturnType` overload resolution — already works (matches by name + parameter-compatible types)
+
+## Known Learnings Applied
+
+`docs/solutions/` was searched for keywords related to this feature (convert, parse, toString, toInt, toDouble, toBoolean, overload, module, register, std, base). Existing solution docs concern struct type resolution and classloading; none directly apply to a static utility class with primitive/String signatures.
+
+- None directly applicable. The existing `Strings`/`Assertions` modules are the strongest precedent — both work without infrastructure changes, which sets the expectation that this work is also infrastructure-free.
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Overload resolution picks the wrong `toString` variant in compile mode | L | M | `FunCallCompiler.discoverReturnType` already handles this for `Strings.sub(String, int, int)`. Cover all three overloads with explicit compile-mode tests; `Ambiguous module function` would fail loudly at compile time. |
+| `Convert.toString(int)` clashes with `Object.toString()` inherited on the class | L | L | Methods are `static`, so they live on the class not instances; reflection scans `getDeclaredMethods()` which excludes inherited members. No conflict. |
+| `Double.parseDouble` parses `"3,14"` differently across locales | L | L | `Double.parseDouble` is locale-independent (always `.`-decimal). Document in Javadoc. |
+| `Integer.parseInt` does not accept `"+1"` on JDK < 7, or accepts it on ≥ 7 | L | L | Project uses modern JDK; default behavior accepts leading `+`. Tests use unsigned and `-` cases only. |
+| Coverage drops below 80% if some overloads or branches are untested | M | M | Each overload + parsing target has at least one positive test; `toBoolean` covered with both `"true"`, `"false"`, and a non-`"true"` case to exercise both Boolean.parseBoolean branches. |
+| `toString` shadows `java.lang.Object.toString()` confusing the static-method scanner | L | L | The scanner filters by `Modifier.isStatic`; Object's `toString` is instance-level and excluded. Verified by inspection of `FunCallCompiler.discoverReturnType`. |
+| Adding `Convert` between alphabetical positions in `BaseModuleRegister` breaks the `SortKey` ordering comment | L | L | Insert AFTER `Assertions`, leaving the `SortKey`-before-`Arrays` invariant untouched. |


### PR DESCRIPTION
Closes #47

## Summary

Adds `com.elminster.jcp.module.base.convert.Convert` — a base-module STD utility class providing simple type conversion between primitives and `String`, callable from JCP programs in both eval and compile modes. Mirrors the precedent set by `Strings` and `Assertions`.

## Changes

- **`Convert.java`** (new): 6 static methods — `intToString(int)`, `doubleToString(double)`, `booleanToString(boolean)`, `toInt(String)`, `toDouble(String)`, `toBoolean(String)`. Each delegates directly to a single `String` / `Integer` / `Double` / `Boolean` call. Private constructor; no defensive try/catch; bad numeric input propagates `NumberFormatException` naturally.
- **`BaseModuleRegister`**: register `Convert.class` (alphabetical position: after `Assertions`, before `Logger`).
- **`ConvertTest.java`** (eval mode, new): 6 tests covering all 6 methods including `toBoolean` case-insensitivity (`"TRUE"` → true) and non-`"true"` input (`"yes"` → false).
- **`ConvertCompileTest.java`** (compile mode, new): 6 tests using `Assertions.assertEquals` / `assertTrue` / `assertFalse` inside the generated `main` method.
- **`docs/plans/2026-05-27-feat-convert-std-api-plan.md`** (new): implementation plan written during `/gw-plan`.

## Plan deviation

The plan proposed three `toString` overloads (one each for `int` / `double` / `boolean`). In practice JCP's module-function resolver (`FunCallCompiler.discoverReturnType`) matches by type-compatibility rather than picking the most-specific overload — `INT.isCompatibleWith(DOUBLE)` is true (numeric promotion), so all three overloads collide on any `int`-arg call (`CompileException: Ambiguous module function`). Resolved by giving each variant a distinct method name (`intToString` / `doubleToString` / `booleanToString`), which keeps the plan's "no infrastructure changes" constraint while still exposing all three primitive→String conversions. Documented this gotcha in repo memory for future module work.

## Testing

- [x] `mvn test -pl core -Dtest='ConvertTest,ConvertCompileTest'` — 12/12 pass
- [x] `mvn verify -pl core` — 1186/1186 tests pass; JaCoCo coverage thresholds met
- [x] `Convert.java` shows 100% instruction coverage (18/18) in JaCoCo report

## Checklist

- [x] Code follows project conventions (mirrors `Strings`/`Assertions` shape)
- [x] Tests added for eval and compile modes — every method exercised in both
- [x] No infrastructure changes (no edits to `TypeMapper`, `CompileModeClassConverter`, evaluators, or compilers)
- [x] Plan document committed under `docs/plans/`