### PR TITLE
feat: Math STD API for base module

### DIFF
--- a/core/src/main/java/com/elminster/jcp/eval/data/DataType.java
+++ b/core/src/main/java/com/elminster/jcp/eval/data/DataType.java
@@ -94,4 +94,43 @@ public interface DataType {
   default boolean isCompatibleWith(DataType target) {
     return isCastableTo(target) || isTypePromotableTo(target);
   }
+
+  /**
+   * Check if this type is an <em>exact</em> match for the target type, i.e. the same
+   * type by name — no hierarchy walk, no numeric widening.
+   *
+   * <p>Used by overload resolution to prefer an exact-type overload over a
+   * widening/hierarchy-compatible one. For example, given {@code abs(int)} and
+   * {@code abs(double)}, an INT argument is compatible with both (INT widens to
+   * DOUBLE) but is an exact match only for {@code abs(int)}.
+   *
+   * @param target the target data type (e.g., parameter type)
+   * @return true if this type equals the target type by name
+   */
+  default boolean isExactMatch(DataType target) {
+    return getName().equals(target.getName());
+  }
+
+  /**
+   * Check whether every argument type is an {@link #isExactMatch(DataType) exact match}
+   * for the corresponding parameter type. Array lengths must already be equal.
+   *
+   * <p>Shared by the eval and compile overload resolvers so both narrow candidates
+   * identically.
+   *
+   * @param argTypes   the argument types of a call
+   * @param paramTypes the parameter types of a candidate method/function
+   * @return true if all positions match exactly by name
+   */
+  static boolean allExactMatch(DataType[] argTypes, DataType[] paramTypes) {
+    if (argTypes.length != paramTypes.length) {
+      return false;
+    }
+    for (int i = 0; i < argTypes.length; i++) {
+      if (!argTypes[i].isExactMatch(paramTypes[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/core/src/main/java/com/elminster/jcp/eval/data/ExternalClassType.java
+++ b/core/src/main/java/com/elminster/jcp/eval/data/ExternalClassType.java
@@ -173,11 +173,24 @@ public class ExternalClassType implements DataType {
             return null;
         } else if (matches.size() == 1) {
             return matches.get(0);
-        } else {
-            throw new IllegalArgumentException(
-                String.format("Ambiguous method call: multiple methods named '%s' match the argument types",
-                    methodName));
         }
+
+        // More than one compatible candidate: prefer an exact-type match over a
+        // widening/hierarchy match (e.g. abs(int) vs abs(double) for an INT arg).
+        List<ExternalMethodDef> exactMatches = new ArrayList<>();
+        for (ExternalMethodDef method : matches) {
+            if (DataType.allExactMatch(argTypes, method.getParameterTypes())) {
+                exactMatches.add(method);
+            }
+        }
+        if (exactMatches.size() == 1) {
+            return exactMatches.get(0);
+        }
+
+        // Zero or multiple exact matches: genuinely ambiguous.
+        throw new IllegalArgumentException(
+            String.format("Ambiguous method call: multiple methods named '%s' match the argument types",
+                methodName));
     }
 
     /**

--- a/core/src/main/java/com/elminster/jcp/eval/function/FunCallEvaluator.java
+++ b/core/src/main/java/com/elminster/jcp/eval/function/FunCallEvaluator.java
@@ -63,6 +63,12 @@ public class FunCallEvaluator extends AbstractAstEvaluator {
     List<Function> functionCandidates = getFunctionCandidates(functionName,
             moduleName,
             argumentData, evalContext);
+    // When multiple candidates are compatible, prefer an exact-type match over a
+    // widening/hierarchy match (e.g. abs(int) vs abs(double) for an INT arg), mirroring
+    // the compile-mode resolver in ExternalClassType.
+    if (functionCandidates.size() > 1) {
+      functionCandidates = narrowToExactMatches(functionCandidates, argumentData);
+    }
     int functionCandidateSize = functionCandidates.size();
     if (0 == functionCandidateSize) {
       DataType[] dataTypes = Arrays.stream(argumentData).map(
@@ -107,6 +113,31 @@ public class FunCallEvaluator extends AbstractAstEvaluator {
       result[i] = arg;  // No conversion needed
     }
     return result;
+  }
+
+  /**
+   * From a list of already-compatible candidates, keep only those whose parameter
+   * types are an exact match for the argument types. If exactly one exact match
+   * exists, return just that one; otherwise (zero or multiple exact matches) return
+   * the original candidates unchanged so the caller preserves its ambiguity handling.
+   */
+  private List<Function> narrowToExactMatches(List<Function> candidates, Data[] arguments) {
+    if (arguments == null) {
+      return candidates;
+    }
+    DataType[] argTypes = Arrays.stream(arguments)
+            .map(Data::getDataType)
+            .toArray(DataType[]::new);
+    List<Function> exactMatches = candidates.stream()
+            .filter(function -> {
+              ParameterDef[] params = function.getParameterDefs();
+              DataType[] paramTypes = Arrays.stream(params)
+                      .map(ParameterDef::getDataType)
+                      .toArray(DataType[]::new);
+              return DataType.allExactMatch(argTypes, paramTypes);
+            })
+            .collect(Collectors.toList());
+    return exactMatches.size() == 1 ? exactMatches : candidates;
   }
 
   private List<Function> getFunctionCandidates(final String functionName,

--- a/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
@@ -5,6 +5,7 @@ import com.elminster.jcp.module.base.arrays.SortKey;
 import com.elminster.jcp.module.base.assertions.Assertions;
 import com.elminster.jcp.module.base.convert.Convert;
 import com.elminster.jcp.module.base.logger.Logger;
+import com.elminster.jcp.module.base.math.Math;
 import com.elminster.jcp.module.base.strings.Strings;
 import com.elminster.jcp.module.base.vb.ValueBuffer;
 
@@ -20,6 +21,7 @@ public class BaseModuleRegister {
         classes.add(Assertions.class);
         classes.add(Convert.class);
         classes.add(Logger.class);
+        classes.add(Math.class);
         classes.add(Strings.class);
         classes.add(ValueBuffer.class);
 

--- a/core/src/main/java/com/elminster/jcp/module/base/math/Math.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/math/Math.java
@@ -1,0 +1,74 @@
+package com.elminster.jcp.module.base.math;
+
+/**
+ * Numeric utilities for the JCP base module.
+ *
+ * <p>All methods are static and delegate directly to {@link java.lang.Math}. The
+ * caller writes one clean name (e.g. {@code Math.abs(x)}); the typed Java overloads
+ * live underneath and overload resolution selects the exact-type implementation —
+ * C {@code <tgmath.h>} semantics.
+ *
+ * <p>Unlike {@link com.elminster.jcp.module.base.convert.Convert} — which uses
+ * distinct method names because it predates the exact-match resolver — {@code Math}
+ * relies on the resolver preferring an exact-type overload over a widening one. An
+ * INT argument to {@code abs} selects {@code abs(int)} (returning int, no type loss);
+ * a DOUBLE argument selects {@code abs(double)}. Methods that only make sense over
+ * reals ({@code sqrt}, {@code pow}, {@code floor}, {@code ceil}) expose a single
+ * {@code double} overload; INT arguments widen to double automatically.
+ *
+ * <p>Callable from JCP programs as:
+ * <pre>
+ *   Math.abs(-5)          // → 5   (int)
+ *   Math.abs(-5.0)        // → 5.0 (double)
+ *   Math.sqrt(9)          // → 3.0 (int widens to double)
+ *   Math.min(1, 2.0)      // → 1.0 (mixed args promote to double,double)
+ *   base::Math.max(3, 4)  // explicit module form
+ * </pre>
+ *
+ * @author jgu
+ * @version 1.0
+ */
+public class Math {
+
+    private Math() {}
+
+    public static int abs(int v) {
+        return java.lang.Math.abs(v);
+    }
+
+    public static double abs(double v) {
+        return java.lang.Math.abs(v);
+    }
+
+    public static double sqrt(double v) {
+        return java.lang.Math.sqrt(v);
+    }
+
+    public static int min(int a, int b) {
+        return java.lang.Math.min(a, b);
+    }
+
+    public static double min(double a, double b) {
+        return java.lang.Math.min(a, b);
+    }
+
+    public static int max(int a, int b) {
+        return java.lang.Math.max(a, b);
+    }
+
+    public static double max(double a, double b) {
+        return java.lang.Math.max(a, b);
+    }
+
+    public static double pow(double a, double b) {
+        return java.lang.Math.pow(a, b);
+    }
+
+    public static double floor(double v) {
+        return java.lang.Math.floor(v);
+    }
+
+    public static double ceil(double v) {
+        return java.lang.Math.ceil(v);
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/compile/module/MathCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/MathCompileTest.java
@@ -1,8 +1,10 @@
 package com.elminster.jcp.compile.module;
 
+import com.elminster.jcp.ast.Expression;
 import com.elminster.jcp.ast.expression.LiteralExpression;
 import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
 import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.operation.Plus;
 import com.elminster.jcp.ast.statement.Block;
 import com.elminster.jcp.ast.statement.BlockImpl;
 import com.elminster.jcp.ast.statement.ExpressionStatement;
@@ -29,7 +31,7 @@ public class MathCompileTest extends AbstractCompileTest {
     }
 
     private StaticMethodCallExpression assertEq(LiteralExpression expected,
-                                                StaticMethodCallExpression actual) {
+                                                Expression actual) {
         return new StaticMethodCallExpression("Assertions", "assertEquals", expected, actual);
     }
 
@@ -146,6 +148,33 @@ public class MathCompileTest extends AbstractCompileTest {
         Method main = compileStatements("TestMathCeil",
             assertEq(dbl(3.0), math("ceil", dbl(2.1))),
             assertEq(dbl(-2.0), math("ceil", dbl(-2.7))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- implicit cast: combining an INT-returning and a DOUBLE-returning
+    //     Math call in an arithmetic expression widens the result to DOUBLE ---
+
+    @Test
+    void testAbsIntPlusAbsDoubleWidensToDouble() throws Exception {
+        // Math.abs(-5) [INT 5] + Math.abs(-5.0) [DOUBLE 5.0] => 10.0 (DOUBLE)
+        Method main = compileStatements("TestMathAbsIntPlusAbsDouble",
+            assertEq(dbl(10.0), new Plus(math("abs", int_(-5)), math("abs", dbl(-5.0)))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testMaxIntPlusSqrtDoubleWidensToDouble() throws Exception {
+        // Math.max(2, 3) [INT 3] + Math.sqrt(9.0) [DOUBLE 3.0] => 6.0 (DOUBLE)
+        Method main = compileStatements("TestMathMaxIntPlusSqrtDouble",
+            assertEq(dbl(6.0), new Plus(math("max", int_(2), int_(3)), math("sqrt", dbl(9.0)))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testFloorDoublePlusMinIntWidensToDouble() throws Exception {
+        // Math.floor(2.7) [DOUBLE 2.0] + Math.min(1, 4) [INT 1] => 3.0 (DOUBLE)
+        Method main = compileStatements("TestMathFloorDoublePlusMinInt",
+            assertEq(dbl(3.0), new Plus(math("floor", dbl(2.7)), math("min", int_(1), int_(4)))));
         assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
     }
 }

--- a/core/src/test/java/com/elminster/jcp/compile/module/MathCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/MathCompileTest.java
@@ -1,0 +1,151 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.compile.AbstractCompileTest;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code Math} base-module STD class in compile mode.
+ *
+ * <p>Each method is verified by compiling an inline {@code Assertions.assertEquals}
+ * call inside the generated {@code main} method. The exact-match overload resolver
+ * is exercised by passing int vs double literals: {@code Math.abs(-5)} selects
+ * {@code abs(int)} (INT result), {@code Math.abs(-5.0)} selects {@code abs(double)}
+ * (DOUBLE result). Mixed-arg {@code Math.min(1, 2.0)} promotes to {@code (double,double)}.
+ */
+public class MathCompileTest extends AbstractCompileTest {
+
+    private StaticMethodCallExpression math(String method, LiteralExpression... args) {
+        return new StaticMethodCallExpression("Math", method, args);
+    }
+
+    private StaticMethodCallExpression assertEq(LiteralExpression expected,
+                                                StaticMethodCallExpression actual) {
+        return new StaticMethodCallExpression("Assertions", "assertEquals", expected, actual);
+    }
+
+    private LiteralExpression int_(int n) {
+        return LiteralExpression.of(Literal.of(n));
+    }
+
+    private LiteralExpression dbl(double d) {
+        return LiteralExpression.of(Literal.of(d));
+    }
+
+    private Method compileStatements(String baseName, StaticMethodCallExpression... calls) throws Exception {
+        Block program = new BlockImpl();
+        for (StaticMethodCallExpression c : calls) {
+            program.addStatement(new ExpressionStatement(c));
+        }
+        String className = uniqueClassName(baseName);
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        return clazz.getMethod("main", String[].class);
+    }
+
+    // --- abs: exact-match dispatch keeps int as int, double as double ---
+
+    @Test
+    void testAbsInt() throws Exception {
+        Method main = compileStatements("TestMathAbsInt",
+            assertEq(int_(5), math("abs", int_(-5))),
+            assertEq(int_(7), math("abs", int_(7))),
+            assertEq(int_(0), math("abs", int_(0))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testAbsDouble() throws Exception {
+        Method main = compileStatements("TestMathAbsDouble",
+            assertEq(dbl(5.0), math("abs", dbl(-5.0))),
+            assertEq(dbl(3.14), math("abs", dbl(3.14))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- sqrt: double-only, int arg widens ---
+
+    @Test
+    void testSqrt() throws Exception {
+        Method main = compileStatements("TestMathSqrt",
+            assertEq(dbl(3.0), math("sqrt", dbl(9.0))),
+            assertEq(dbl(0.0), math("sqrt", dbl(0.0))),
+            assertEq(dbl(2.0), math("sqrt", int_(4))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- min / max: int and double overloads ---
+
+    @Test
+    void testMinInt() throws Exception {
+        Method main = compileStatements("TestMathMinInt",
+            assertEq(int_(1), math("min", int_(1), int_(2))),
+            assertEq(int_(-3), math("min", int_(-3), int_(0))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testMinDouble() throws Exception {
+        Method main = compileStatements("TestMathMinDouble",
+            assertEq(dbl(1.5), math("min", dbl(1.5), dbl(2.5))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testMinMixedArgsPromote() throws Exception {
+        // (int, double) matches only (double,double) → 1.0
+        Method main = compileStatements("TestMathMinMixed",
+            assertEq(dbl(1.0), math("min", int_(1), dbl(2.0))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testMaxInt() throws Exception {
+        Method main = compileStatements("TestMathMaxInt",
+            assertEq(int_(2), math("max", int_(1), int_(2))),
+            assertEq(int_(0), math("max", int_(-3), int_(0))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testMaxDouble() throws Exception {
+        Method main = compileStatements("TestMathMaxDouble",
+            assertEq(dbl(2.5), math("max", dbl(1.5), dbl(2.5))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- pow: double-only, int args widen ---
+
+    @Test
+    void testPow() throws Exception {
+        Method main = compileStatements("TestMathPow",
+            assertEq(dbl(1024.0), math("pow", dbl(2.0), dbl(10.0))),
+            assertEq(dbl(8.0), math("pow", int_(2), int_(3))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    // --- floor / ceil: double-only ---
+
+    @Test
+    void testFloor() throws Exception {
+        Method main = compileStatements("TestMathFloor",
+            assertEq(dbl(2.0), math("floor", dbl(2.7))),
+            assertEq(dbl(-3.0), math("floor", dbl(-2.1))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testCeil() throws Exception {
+        Method main = compileStatements("TestMathCeil",
+            assertEq(dbl(3.0), math("ceil", dbl(2.1))),
+            assertEq(dbl(-2.0), math("ceil", dbl(-2.7))));
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/data/ExternalClassTypeTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/data/ExternalClassTypeTest.java
@@ -249,6 +249,39 @@ class ExternalClassTypeTest {
                 classType.getStaticMethod("process", new DataType[]{SystemDataType.INT})
             );
         }
+
+        /**
+         * Two overloads {@code abs(int)} and {@code abs(double)} both match an INT
+         * argument (INT widens to DOUBLE), but the exact-match resolver must prefer
+         * the {@code abs(int)} overload rather than throwing an ambiguity error.
+         */
+        @Test
+        void testExactMatchPreferredOverWidening() throws Exception {
+            Method valueOf = String.class.getMethod("valueOf", int.class);
+
+            ExternalMethodDef absInt = new ExternalMethodDef(
+                valueOf, "abs",
+                new DataType[]{SystemDataType.INT},
+                SystemDataType.INT, "(I)I", true);
+            ExternalMethodDef absDouble = new ExternalMethodDef(
+                valueOf, "abs",
+                new DataType[]{SystemDataType.DOUBLE},
+                SystemDataType.DOUBLE, "(D)D", true);
+            classType.addStaticMethod(absInt);
+            classType.addStaticMethod(absDouble);
+
+            // INT arg → exact match is abs(int)
+            ExternalMethodDef foundInt =
+                classType.getStaticMethod("abs", new DataType[]{SystemDataType.INT});
+            assertNotNull(foundInt);
+            assertEquals(SystemDataType.INT, foundInt.getReturnType());
+
+            // DOUBLE arg → exact match is abs(double)
+            ExternalMethodDef foundDouble =
+                classType.getStaticMethod("abs", new DataType[]{SystemDataType.DOUBLE});
+            assertNotNull(foundDouble);
+            assertEquals(SystemDataType.DOUBLE, foundDouble.getReturnType());
+        }
     }
 
     @Nested

--- a/core/src/test/java/com/elminster/jcp/eval/declare/TypeDeclarationEvaluatorTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/declare/TypeDeclarationEvaluatorTest.java
@@ -57,7 +57,7 @@ class TypeDeclarationEvaluatorTest {
     /**
      * Tests type declaration with static method (no parameters).
      * <pre>
-     * type Math {
+     * type Calc {
      *   static fun zero() -> Int { }
      * }
      * </pre>
@@ -70,7 +70,7 @@ class TypeDeclarationEvaluatorTest {
         MethodDef zeroMethod = MethodDef.staticMethod("zero", SystemDataType.INT, methodBody);
 
         StructDeclarationImpl typeDecl = new StructDeclarationImpl(
-            "Math",
+            "Calc",
             Collections.emptyList(),  // no fields
             null,  // no constructor
             Collections.emptyList(),  // no instance methods
@@ -80,9 +80,9 @@ class TypeDeclarationEvaluatorTest {
         new EvalVisitor(context).visit(new BlockImpl(typeDecl));
 
         // Type should be registered
-        StructType type = (StructType) context.getDataType("Math");
+        StructType type = (StructType) context.getDataType("Calc");
         assertNotNull(type);
-        assertEquals("Math", type.getName());
+        assertEquals("Calc", type.getName());
     }
 
     /**
@@ -121,7 +121,7 @@ class TypeDeclarationEvaluatorTest {
     /**
      * Tests type declaration with static method with parameters.
      * <pre>
-     * type Math {
+     * type Calc {
      *   static fun add(a: Int, b: Int) -> Int { }
      * }
      * </pre>
@@ -136,7 +136,7 @@ class TypeDeclarationEvaluatorTest {
             ParameterDef.of("b", SystemDataType.INT));
 
         StructDeclarationImpl typeDecl = new StructDeclarationImpl(
-            "Math",
+            "Calc",
             Collections.emptyList(),  // no fields
             null,  // no constructor
             Collections.emptyList(),  // no instance methods
@@ -146,9 +146,9 @@ class TypeDeclarationEvaluatorTest {
         new EvalVisitor(context).visit(new BlockImpl(typeDecl));
 
         // Type should be registered
-        StructType type = (StructType) context.getDataType("Math");
+        StructType type = (StructType) context.getDataType("Calc");
         assertNotNull(type);
-        assertEquals("Math", type.getName());
+        assertEquals("Calc", type.getName());
     }
 
     /**
@@ -190,7 +190,7 @@ class TypeDeclarationEvaluatorTest {
         MethodDef zeroMethod = MethodDef.staticMethod("zero", SystemDataType.INT, methodBody, (ParameterDef[]) null);
 
         StructDeclarationImpl typeDecl = new StructDeclarationImpl(
-            "Math",
+            "Calc",
             Collections.emptyList(),
             null,
             Collections.emptyList(),
@@ -199,7 +199,7 @@ class TypeDeclarationEvaluatorTest {
 
         new EvalVisitor(context).visit(new BlockImpl(typeDecl));
 
-        StructType type = (StructType) context.getDataType("Math");
+        StructType type = (StructType) context.getDataType("Calc");
         assertNotNull(type);
     }
 }

--- a/core/src/test/java/com/elminster/jcp/eval/function/FunCallEvaluatorTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/FunCallEvaluatorTest.java
@@ -460,16 +460,21 @@ class FunCallEvaluatorTest {
         }
 
         /**
-         * Tests that having both INT and DOUBLE overloads causes ambiguity when called with INT.
-         * This follows the plan's recommendation: when multiple widening paths exist, fail at compile time.
+         * Tests that with both INT and DOUBLE overloads, an INT argument selects the
+         * exact-match INT overload rather than throwing an ambiguity error.
+         *
+         * <p>Prior to issue #43 this threw {@link FunctionAmbiguityException} because
+         * INT is compatible with both {@code process(int)} (exact) and
+         * {@code process(double)} (widening). The exact-match resolver now prefers the
+         * exact overload, giving C {@code <tgmath.h>}-style dispatch.
          * <pre>
          * fn process(x: Int) -> Int { return x * 2 }
          * fn process(x: Double) -> Double { return x * 3.0 }
-         * result = process(5)  // throws FunctionAmbiguityException (both match)
+         * result = process(5)  // selects process(int) -> 10
          * </pre>
          */
         @Test
-        void testOverloadResolution_IntDoubleAmbiguity() {
+        void testOverloadResolution_IntPrefersExactOverWidening() {
             // INT version: process(int) -> int { return x * 2 }
             Function intFunc = new AbstractFunction(
                 IdentifierExpression.of("process"),
@@ -494,7 +499,7 @@ class FunCallEvaluatorTest {
             );
             context.addFunction(doubleFunc);
 
-            // Call with INT - both functions match (exact + widening), causes ambiguity
+            // Call with INT - exact match is process(int) -> 5 * 2 = 10
             Block program = new BlockImpl();
             program.addStatement(new VariableDeclarationImpl(
                 "result",
@@ -505,9 +510,56 @@ class FunCallEvaluatorTest {
                 )
             ));
 
-            assertThrows(FunctionAmbiguityException.class, () ->
-                new EvalVisitor(context).visit(program)
+            new EvalVisitor(context).visit(program);
+            assertEquals(10, context.getVariable("result").get());
+        }
+
+        /**
+         * Tests that a DOUBLE argument selects the exact-match DOUBLE overload when
+         * both INT and DOUBLE overloads exist.
+         * <pre>
+         * fn process(x: Int) -> Int { return x * 2 }
+         * fn process(x: Double) -> Double { return x * 3.0 }
+         * result = process(5.0)  // selects process(double) -> 15.0
+         * </pre>
+         */
+        @Test
+        void testOverloadResolution_DoublePrefersExact() {
+            Function intFunc = new AbstractFunction(
+                IdentifierExpression.of("process"),
+                new ParameterDef[]{ParameterDef.of("x", SystemDataType.INT)},
+                SystemDataType.INT,
+                new ReturnStatement(new Multi(
+                    new VariableExpression(IdentifierExpression.of("x")),
+                    LiteralExpression.of(2)
+                ))
             );
+            context.addFunction(intFunc);
+
+            Function doubleFunc = new AbstractFunction(
+                IdentifierExpression.of("process"),
+                new ParameterDef[]{ParameterDef.of("x", SystemDataType.DOUBLE)},
+                SystemDataType.DOUBLE,
+                new ReturnStatement(new Multi(
+                    new VariableExpression(IdentifierExpression.of("x")),
+                    LiteralExpression.of(3.0)
+                ))
+            );
+            context.addFunction(doubleFunc);
+
+            // Call with DOUBLE - exact match is process(double) -> 5.0 * 3.0 = 15.0
+            Block program = new BlockImpl();
+            program.addStatement(new VariableDeclarationImpl(
+                "result",
+                SystemDataType.DOUBLE,
+                new FunctionCallExpression(
+                    IdentifierExpression.of("process"),
+                    LiteralExpression.of(5.0)  // DOUBLE
+                )
+            ));
+
+            new EvalVisitor(context).visit(program);
+            assertEquals(15.0, (Double) context.getVariable("result").get(), 0.001);
         }
 
         /**

--- a/core/src/test/java/com/elminster/jcp/eval/function/MathTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/MathTest.java
@@ -1,9 +1,11 @@
 package com.elminster.jcp.eval.function;
 
 import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.Expression;
 import com.elminster.jcp.ast.expression.LiteralExpression;
 import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
 import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.operation.Plus;
 import com.elminster.jcp.ast.statement.Block;
 import com.elminster.jcp.ast.statement.BlockImpl;
 import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
@@ -36,6 +38,18 @@ public class MathTest {
             "result", returnType,
             new FunctionCallExpression(Identifier.fromName("Math." + method), args)
         ));
+        new EvalVisitor(context).visit(program);
+        return context.getVariable("result").get();
+    }
+
+    private FunctionCallExpression call(String method, Expression... args) {
+        return new FunctionCallExpression(Identifier.fromName("Math." + method), args);
+    }
+
+    private Object evalExpr(SystemDataType returnType, Expression expr) {
+        EvalContext context = newContext();
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl("result", returnType, expr));
         new EvalVisitor(context).visit(program);
         return context.getVariable("result").get();
     }
@@ -124,5 +138,29 @@ public class MathTest {
     void testCeil() {
         assertEquals(3.0, eval("ceil", SystemDataType.DOUBLE, dbl(2.1)));
         assertEquals(-2.0, eval("ceil", SystemDataType.DOUBLE, dbl(-2.7)));
+    }
+
+    // --- implicit cast: combining an INT-returning and a DOUBLE-returning
+    //     Math call in an arithmetic expression widens the result to DOUBLE ---
+
+    @Test
+    void testAbsIntPlusAbsDoubleWidensToDouble() {
+        // Math.abs(-5) [INT 5] + Math.abs(-5.0) [DOUBLE 5.0] => 10.0 (DOUBLE)
+        assertEquals(10.0, evalExpr(SystemDataType.DOUBLE,
+            new Plus(call("abs", int_(-5)), call("abs", dbl(-5.0)))));
+    }
+
+    @Test
+    void testMaxIntPlusSqrtDoubleWidensToDouble() {
+        // Math.max(2, 3) [INT 3] + Math.sqrt(9.0) [DOUBLE 3.0] => 6.0 (DOUBLE)
+        assertEquals(6.0, evalExpr(SystemDataType.DOUBLE,
+            new Plus(call("max", int_(2), int_(3)), call("sqrt", dbl(9.0)))));
+    }
+
+    @Test
+    void testFloorDoublePlusMinIntWidensToDouble() {
+        // Math.floor(2.7) [DOUBLE 2.0] + Math.min(1, 4) [INT 1] => 3.0 (DOUBLE)
+        assertEquals(3.0, evalExpr(SystemDataType.DOUBLE,
+            new Plus(call("floor", dbl(2.7)), call("min", int_(1), int_(4)))));
     }
 }

--- a/core/src/test/java/com/elminster/jcp/eval/function/MathTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/MathTest.java
@@ -1,0 +1,128 @@
+package com.elminster.jcp.eval.function;
+
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
+import com.elminster.jcp.eval.EvalVisitor;
+import com.elminster.jcp.eval.context.EvalContext;
+import com.elminster.jcp.eval.context.RootEvalContext;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code Math} base-module STD class in eval mode.
+ *
+ * <p>Exercises every method with int and double arguments and verifies the
+ * exact-match overload resolver: {@code Math.abs(-5)} returns an INT while
+ * {@code Math.abs(-5.0)} returns a DOUBLE, with no type loss. Mixed-arg
+ * {@code Math.min(1, 2.0)} promotes to the {@code (double,double)} overload.
+ */
+public class MathTest {
+
+    private EvalContext newContext() {
+        return new RootEvalContext();
+    }
+
+    private Object eval(String method, SystemDataType returnType, LiteralExpression... args) {
+        EvalContext context = newContext();
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "result", returnType,
+            new FunctionCallExpression(Identifier.fromName("Math." + method), args)
+        ));
+        new EvalVisitor(context).visit(program);
+        return context.getVariable("result").get();
+    }
+
+    private LiteralExpression int_(int n) {
+        return LiteralExpression.of(Literal.of(n));
+    }
+
+    private LiteralExpression dbl(double d) {
+        return LiteralExpression.of(Literal.of(d));
+    }
+
+    // --- abs: exact-match dispatch keeps int as int, double as double ---
+
+    @Test
+    void testAbsInt() {
+        assertEquals(5, eval("abs", SystemDataType.INT, int_(-5)));
+        assertEquals(7, eval("abs", SystemDataType.INT, int_(7)));
+        assertEquals(0, eval("abs", SystemDataType.INT, int_(0)));
+    }
+
+    @Test
+    void testAbsDouble() {
+        assertEquals(5.0, eval("abs", SystemDataType.DOUBLE, dbl(-5.0)));
+        assertEquals(3.14, eval("abs", SystemDataType.DOUBLE, dbl(3.14)));
+    }
+
+    // --- sqrt: double-only, int arg widens ---
+
+    @Test
+    void testSqrt() {
+        assertEquals(3.0, eval("sqrt", SystemDataType.DOUBLE, dbl(9.0)));
+        assertEquals(0.0, eval("sqrt", SystemDataType.DOUBLE, dbl(0.0)));
+        // int argument widens to double
+        assertEquals(2.0, eval("sqrt", SystemDataType.DOUBLE, int_(4)));
+    }
+
+    // --- min / max: int and double overloads ---
+
+    @Test
+    void testMinInt() {
+        assertEquals(1, eval("min", SystemDataType.INT, int_(1), int_(2)));
+        assertEquals(-3, eval("min", SystemDataType.INT, int_(-3), int_(0)));
+    }
+
+    @Test
+    void testMinDouble() {
+        assertEquals(1.5, eval("min", SystemDataType.DOUBLE, dbl(1.5), dbl(2.5)));
+    }
+
+    @Test
+    void testMinMixedArgsPromote() {
+        // (int, double) has no int,int overload match; only (double,double) matches → 1.0
+        assertEquals(1.0, eval("min", SystemDataType.DOUBLE, int_(1), dbl(2.0)));
+    }
+
+    @Test
+    void testMaxInt() {
+        assertEquals(2, eval("max", SystemDataType.INT, int_(1), int_(2)));
+        assertEquals(0, eval("max", SystemDataType.INT, int_(-3), int_(0)));
+    }
+
+    @Test
+    void testMaxDouble() {
+        assertEquals(2.5, eval("max", SystemDataType.DOUBLE, dbl(1.5), dbl(2.5)));
+    }
+
+    // --- pow: double-only, int args widen ---
+
+    @Test
+    void testPow() {
+        assertEquals(1024.0, eval("pow", SystemDataType.DOUBLE, dbl(2.0), dbl(10.0)));
+        // int args widen to double
+        assertEquals(8.0, eval("pow", SystemDataType.DOUBLE, int_(2), int_(3)));
+    }
+
+    // --- floor / ceil: double-only ---
+
+    @Test
+    void testFloor() {
+        assertEquals(2.0, eval("floor", SystemDataType.DOUBLE, dbl(2.7)));
+        assertEquals(-3.0, eval("floor", SystemDataType.DOUBLE, dbl(-2.1)));
+    }
+
+    @Test
+    void testCeil() {
+        assertEquals(3.0, eval("ceil", SystemDataType.DOUBLE, dbl(2.1)));
+        assertEquals(-2.0, eval("ceil", SystemDataType.DOUBLE, dbl(-2.7)));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/struct/TypeMethodEvaluatorTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/struct/TypeMethodEvaluatorTest.java
@@ -89,10 +89,10 @@ class TypeMethodEvaluatorTest {
 
   @Test
   void testStaticMethod() {
-    // type Math {
+    // type Calc {
     //   static func add(int a, int b) -> int { return a + b; }
     // }
-    // int result = Math.add(2, 3);
+    // int result = Calc.add(2, 3);
 
     Block program = new BlockImpl();
 
@@ -115,7 +115,7 @@ class TypeMethodEvaluatorTest {
 
     // Type declaration with static method only (no fields)
     StructDeclarationImpl typeDecl = new StructDeclarationImpl(
-        "Math",
+        "Calc",
         Collections.emptyList(),  // no fields
         null,                     // no constructor
         Collections.emptyList(),  // no instance methods
@@ -123,9 +123,9 @@ class TypeMethodEvaluatorTest {
     );
     program.addStatement(typeDecl);
 
-    // int result = Math.add(2, 3);
+    // int result = Calc.add(2, 3);
     StaticMethodCallExpression methodCall = new StaticMethodCallExpression(
-        "Math",
+        "Calc",
         "add",
         LiteralExpression.of(IntLiteral.of(2)),
         LiteralExpression.of(IntLiteral.of(3))

--- a/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan-enhanced.md
+++ b/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan-enhanced.md
@@ -1,0 +1,189 @@
+---
+title: "feat: Math STD API for base module (Enhanced)"
+type: feat
+date: 2026-08-05
+issue: 43
+review_date: 2026-08-05
+original_plan: docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan.md
+---
+
+# feat: Math STD API for base module (Enhanced)
+
+> **Note:** Enhanced version incorporating the 2026-08-05 plan review. The material
+> change: the overload-resolution fix must be applied in **two** resolvers (eval +
+> compile), and the former blocking risk **R3 is resolved** — verified empirically
+> that eval mode already widens int→double for double-only methods.
+
+## Overview
+
+Implement `Math` as a base module STD class exposing seven numeric operations —
+`abs`, `sqrt`, `min`, `max`, `pow`, `floor`, `ceil` — callable from DSL code as
+`Math.abs(x)` (or `base::Math.abs(x)`) in both eval and compile modes, following
+the established STD pattern (`Convert`, `Arrays`, `Assertions`).
+
+The caller writes one clean name (`Math.abs`); typed Java overloads live
+underneath; dispatch selects the exact-type implementation — C `<tgmath.h>`
+semantics. This requires a small, symmetric fix to overload resolution in both
+execution modes.
+
+## Technical Approach
+
+### Verified invocation paths (corrected from original plan)
+
+STD methods are invoked as a `FunctionCallExpression` whose identifier is the
+dotted name `"Math.abs"` (confirmed in `ConvertTest`, `ArraysTest`). This routes:
+
+- **Eval mode → `FunCallEvaluator`** (NOT `StaticMethodCallEvaluator`):
+  - `getFunctionCandidates` filters by `isCompatibleWith` (hierarchy + widening).
+  - `applyWideningConversions` converts INT args to `DoubleData` for DOUBLE params.
+  - **Verified:** `Convert.doubleToString(5)` → `"5.0"`. Int args reach double-only
+    methods correctly. → **R3 does not exist.**
+  - **BUT:** when >1 candidate is compatible, it throws `FunctionAmbiguityException`
+    (`FunCallEvaluator`, ~L72–76). Since `INT.isCompatibleWith(DOUBLE)` is true,
+    `abs(int)`+`abs(double)` BOTH match an int arg → **ambiguity in eval too.**
+
+- **Compile mode → `StaticMethodCallCompiler`**:
+  - `ExternalClassType.getStaticMethod` → `findMethodWithOverloadResolution`
+    (same compatibility scan) → throws `IllegalArgumentException("Ambiguous ...")`
+    for the same reason.
+  - `I2D` promotion + `INVOKESTATIC` emission already exist (L140–145). No change.
+
+### The fix: exact-match beats promotion — in BOTH resolvers
+
+**Definition of exact match:** for every argument `i`, `argType[i] == paramType[i]`
+(or `argType[i].getName().equals(paramType[i].getName())`). Any compatible match
+that is not exact is a widening/hierarchy match.
+
+**Rule:** after collecting all compatible candidates, if more than one remains,
+keep only exact-match candidates. If exactly one exact match exists, select it.
+Otherwise (zero or ≥2 exact matches) fall back to the existing Ambiguous behavior.
+
+Apply symmetrically in:
+1. `ExternalClassType.findMethodWithOverloadResolution` (compile mode)
+2. `FunCallEvaluator.getFunctionCandidates` / its candidate-narrowing (eval mode)
+
+This resolves `abs(int)` vs `abs(double)` identically in both modes, preserves
+INT→INT / DOUBLE→DOUBLE return types, and needs no boxing. It also retires the
+project-wide numeric-overload gotcha (Convert's `intToString`/`doubleToString`
+could later collapse to `toString`).
+
+### Overload table (finalized — R3 resolved)
+
+| Method | Overloads | Return | Notes |
+|--------|-----------|--------|-------|
+| `abs`   | `abs(int)`, `abs(double)` | int / double | Both meaningful; exact-match fix disambiguates. |
+| `min`   | `min(int,int)`, `min(double,double)` | int / double | Mixed args (`min(1,2.0)`) promote to double-double — single candidate. |
+| `max`   | `max(int,int)`, `max(double,double)` | int / double | Same as min. |
+| `sqrt`  | `sqrt(double)` | double | Int arg widens (verified). |
+| `pow`   | `pow(double,double)` | double | Int args widen. |
+| `floor` | `floor(double)` | double | Int arg widens. |
+| `ceil`  | `ceil(double)` | double | Int arg widens. |
+
+All delegate to `java.lang.Math`. Private constructor; class is a static utility.
+
+## Implementation Phases
+
+### Phase 1: Symmetric overload-resolution fix (foundation)
+
+**Deliverables:**
+- [ ] Add exact-match narrowing to `ExternalClassType.findMethodWithOverloadResolution`
+- [ ] Add the same narrowing to `FunCallEvaluator` candidate selection (eval)
+- [ ] Extract/share the "is exact match" predicate to keep both sides identical
+
+**Acceptance Criteria:**
+- [ ] Unit test (compile): `foo(int)`/`foo(double)`; INT arg → int overload, DOUBLE → double
+- [ ] Unit test (eval): same, via `FunCallEvaluator`
+- [ ] Genuine ambiguity (two `ANY`-param overloads, no exact match) still throws in both modes
+- [ ] **Full existing STD suite green** — `ConvertTest`, `ArraysTest`, `StringsTest`,
+      `AssertionsTest` + compile counterparts (regression gate for shared resolver)
+
+### Phase 2: Implement `Math` class
+
+**Deliverables:**
+- [ ] `com.elminster.jcp.module.base.math.Math` with private ctor + methods per table
+- [ ] Javadoc in `Convert` style (document single-name/typed-overload design)
+- [ ] Register `Math.class` in `BaseModuleRegister.classToRegister()`
+
+**Acceptance Criteria:**
+- [ ] Class compiles; registered in both eval and compile registration flows
+
+### Phase 3: Tests (both modes)
+
+**Deliverables:**
+- [ ] `eval/function/MathTest.java` — every method, int + double args, edge cases
+      (negative abs, `sqrt(0)`, `pow(2,10)`, `floor(2.7)`, `ceil(2.1)`)
+- [ ] `compile/module/MathCompileTest.java` (extends `AbstractCompileTest`, mirrors
+      `ConvertCompileTest`) — same coverage via inline `Assertions.assertEquals`
+- [ ] Dispatch test: `Math.abs(-5)`→INT `5`; `Math.abs(-5.0)`→DOUBLE `5.0` (both modes)
+- [ ] Mixed-arg test: `Math.min(1, 2.0)` → `1.0` (double), no ambiguity (both modes)
+
+**Acceptance Criteria:**
+- [ ] `mvn verify -pl core` passes JaCoCo ≥ 80% instruction & branch
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] All 7 methods callable in eval AND compile modes
+- [ ] `Math.abs(int)`→INT, `Math.abs(double)`→DOUBLE (no type loss)
+- [ ] `sqrt`/`pow`/`floor`/`ceil` accept int args (widen to double) in both modes
+- [ ] `Math.min(1, 2.0)` resolves unambiguously in both modes
+- [ ] Resolver fix breaks no existing STD test
+
+### Non-Functional Requirements
+
+- [ ] Coverage ≥ 80% instruction and branch (JaCoCo)
+- [ ] No new runtime dependencies (delegates to `java.lang.Math`)
+- [ ] Work on branch `feat/43-math-std-api`; PR to master (never commit to master)
+- [ ] Shared resolver change reviewed for blast radius before merge
+
+## Dependencies
+
+- Phase 1 (both-resolver fix) blocks Phases 2–3
+- Existing `AbstractCompileTest`, `StaticMethodCallExpression`, `Literal` helpers
+- Independent of IO (#45)
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| R1: Resolver change alters matching for other STD classes | M | H | Fix only narrows the >1-match case to prefer exact; Phase 1 full-suite regression gate |
+| R2: `min(1, 2.0)` mixed args ambiguous | L | M | Only `(double,double)` matches a double arg → single candidate; explicit test both modes |
+| R4: `pow`/`sqrt` returning DOUBLE surprises int-expecting users | L | L | Documented in Javadoc; matches Java and most languages |
+| R5: Coverage dip from untested overload branches | L | M | Phase 3 tests every overload with int and double literals |
+| **R6 (new): eval + compile resolvers drift out of sync** | M | H | Share one exact-match predicate; test the identical scenario in both modes in Phase 1 |
+| R7: eval fix accidentally suppresses a legitimate ambiguity error | L | M | Fall back to existing throw when zero or ≥2 exact matches; negative test asserts throw preserved |
+
+## Testing Strategy
+
+- **Phase 1 unit tests** target the resolver directly (both modes) — fastest feedback.
+- **Regression gate**: existing STD suites must stay green before Phase 2.
+- **Phase 3** exercises Math end-to-end in both modes, including the two dispatch
+  edge cases (exact-int vs exact-double, mixed promotion).
+- Coverage verified via `mvn verify -pl core`.
+
+## Success Metrics
+
+- 7/7 Math methods pass in both modes
+- Both dispatch edge-case tests pass in both modes
+- Zero regressions in existing STD suites
+- JaCoCo ≥ 80%/80% maintained
+
+## Changes from Original Plan
+
+1. **Two-resolver fix (was one)** — verified eval STD calls go through
+   `FunCallEvaluator`, which throws the same ambiguity as compile mode; the fix is
+   now symmetric across `ExternalClassType` and `FunCallEvaluator`.
+2. **R3 resolved and removed as blocker** — empirically confirmed eval widens
+   int→double (`Convert.doubleToString(5)` → `"5.0"`); double-only methods accept
+   int args, so no int overloads or key-path changes are needed.
+3. **Added R6/R7** — resolver-drift and false-negative-ambiguity risks, with a
+   shared predicate and preserved-throw fallback as mitigations.
+4. **Added regression gate + mixed-arg tests** — full STD suite green as a Phase 1
+   exit condition; `Math.min(1,2.0)` tested in both modes.
+
+## References
+
+- Original plan: `docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan.md`
+- Plan review: `docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan-review.md`
+- Issue: https://github.com/elminsterjimmy/jcp/issues/43

--- a/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan-review.md
+++ b/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan-review.md
@@ -1,0 +1,95 @@
+# Plan Review: feat: Math STD API for base module
+
+**Issue:** #43 | **Reviewer:** Claude Code | **Date:** 2026-08-05
+
+## Overall Assessment
+
+**Status:** Needs Revision (one material correction; otherwise sound)
+**Quality Score:** 7/10
+
+The original plan is well-structured and correctly identifies the core mechanism
+(single clean name + typed overloads + exact-match resolution). However, its
+central risk analysis — **R3** and the claim that "eval mode needs no ambiguity
+fix" — was based on the **wrong evaluator**. Empirical verification during this
+review overturned that assumption and revealed the fix must land in **two**
+resolvers, not one. This is a correctness-affecting gap that would have surfaced
+mid-implementation. Correcting it makes the plan solid.
+
+## What the review verified (empirically)
+
+A throwaway probe (`Convert.doubleToString(5)` with an int literal) and a code
+trace of `FunCallEvaluator` established the ground truth:
+
+| Question | Original plan assumed | Verified reality |
+|----------|----------------------|------------------|
+| Which eval path do STD calls (`Math.abs(x)`) use? | `StaticMethodCallEvaluator` (exact-string key) | **`FunCallEvaluator`** — STD calls are `FunctionCallExpression` with dotted id `"Math.abs"` (see `ConvertTest`/`ArraysTest`) |
+| Does eval widen int→double for a double-only method? | Uncertain (R3 flagged as blocker) | **Yes** — `Convert.doubleToString(5)` returns `"5.0"` |
+| Does eval throw ambiguity on `abs(int)`+`abs(double)`? | "No — eval is safe" | **Yes** — `FunCallEvaluator.getFunction` throws `FunctionAmbiguityException` when >1 candidate; `INT.isCompatibleWith(DOUBLE)` makes both match |
+
+**Consequence:** R3 (double-only methods rejecting int args) is a **non-issue** —
+eval widens correctly. But the ambiguity fix is needed in **BOTH**
+`ExternalClassType.findMethodWithOverloadResolution` (compile) **and**
+`FunCallEvaluator.getFunctionCandidates` (eval).
+
+## Strengths
+
+- ✅ Correctly frames the design as C `<tgmath.h>`-style single-name dispatch
+- ✅ Accurately identifies that compile-mode promotion/boxing (`I2D`) already exists
+- ✅ Sensible overload table (typed `abs`/`min`/`max`; double-only `sqrt`/`pow`/`floor`/`ceil`)
+- ✅ Good test strategy split (eval `MathTest` + compile `MathCompileTest` mirroring `ConvertCompileTest`)
+- ✅ Applies the project's overload-gotcha learning rather than repeating the distinct-name workaround
+
+## Areas for Improvement
+
+### Critical Issues
+
+- ❌ **Resolver fix scope was understated.** Plan said the fix is compile-mode-only
+  (`ExternalClassType`). Verified: eval mode (`FunCallEvaluator`) has the identical
+  ambiguity and must get the symmetric fix. Enhanced plan moves this into Phase 1
+  as a two-file change with tests in both modes.
+- ❌ **R3 was mis-scoped as a blocker.** It was based on `StaticMethodCallEvaluator`,
+  which is not the STD invocation path. Enhanced plan removes R3 as a blocker and
+  documents the verified widening behavior instead.
+
+### Suggestions
+
+- 💡 Define "exact match" precisely for both resolvers: `argType == paramType` (or
+  equal `getName()`); everything else compatible is a widening/hierarchy match.
+- 💡 Add a regression guard: run the full existing STD suite (`ConvertTest`,
+  `ArraysTest`, `StringsTest`, `AssertionsTest`, and their compile counterparts)
+  after the resolver change, since both resolvers are shared infrastructure.
+- 💡 Add an explicit mixed-arg test (`Math.min(1, 2.0)`) — should resolve to
+  `(double,double)` with no ambiguity, in both modes.
+
+## Specific Feedback by Section
+
+### Overview
+Clear problem and objective; correctly ties to brainstorm #62. **8/10**
+
+### Technical Approach
+Sound mechanism, but the eval/compile path analysis had the critical error above.
+Now corrected. **6/10** (→ 9/10 enhanced)
+
+### Implementation Phases
+Logical. Phase 1 needed expansion to cover both resolvers + full-suite regression.
+**7/10**
+
+### Acceptance Criteria
+Testable and concrete. Added mixed-arg + both-mode ambiguity criteria. **8/10**
+
+### Risk Analysis
+R1/R2/R4/R5 are good. R3 was wrong (removed/rewritten). Added R6 (shared-resolver
+regression) as the real top risk. **6/10** (→ 9/10 enhanced)
+
+## Recommended Actions
+
+1. Apply the exact-match-beats-promotion fix in **both** `ExternalClassType` and
+   `FunCallEvaluator`.
+2. Remove R3 as a blocker; document verified widening.
+3. Run the full existing STD test suite as a Phase 1 regression gate.
+4. Add mixed-arg and both-mode ambiguity-resolution tests.
+
+## Sign-off
+
+- [x] All critical issues addressed (in enhanced plan)
+- [x] Plan ready for implementation

--- a/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan.md
+++ b/docs/plans/2026-08-05-feat-math-std-api-for-base-module-plan.md
@@ -1,0 +1,177 @@
+---
+title: "feat: Math STD API for base module"
+type: feat
+date: 2026-08-05
+issue: 43
+---
+
+# feat: Math STD API for base module
+
+## Overview
+
+Implement `Math` as a base module STD class exposing seven numeric operations —
+`abs`, `sqrt`, `min`, `max`, `pow`, `floor`, `ceil` — callable from DSL code as
+`Math.abs(x)` (or `base::Math.abs(x)`) in both eval and compile modes, following
+the established STD pattern (`Convert`, `Arrays`, `Assertions`).
+
+The plan delivers the clean single-name interface decided in the brainstorm
+(#62): the caller writes one name (`Math.abs`), typed Java overloads live
+underneath, and dispatch picks the exact-type implementation — C `<tgmath.h>`
+semantics. This requires one small, targeted fix to compile-mode overload
+resolution.
+
+## Technical Approach
+
+### How STD classes are wired (verified)
+
+- **Registration** happens in `BaseModuleRegister.classToRegister()` — one list,
+  consumed by BOTH modes:
+  - Eval: `RootEvalContext.registerSystemFunctions()` → `ClassConverter.registerClass`
+    registers each public static method as a `Function` keyed by full name
+    `Math.abs#INT`, `Math.abs#DOUBLE`, etc.
+  - Compile: `BytecodeGenerator` → `CompileModeClassConverter.registerClass`
+    builds an `ExternalClassType` with `ExternalMethodDef`s per overload.
+- **Invocation** as `Math.abs(x)` routes through `StaticMethodCallExpression`:
+  - Eval: `StaticMethodCallEvaluator` builds an **exact-string key**
+    (`Math.abs#INT`) and does a direct map lookup — no compatibility scan, so
+    **no ambiguity in eval mode**. Requires the exact typed overload to exist.
+  - Compile: `StaticMethodCallCompiler.compileExternalClassCall` →
+    `ExternalClassType.getStaticMethod(name, argTypes)` →
+    `findMethodWithOverloadResolution`.
+
+### The one real gap: compile-mode overload resolution
+
+`findMethodWithOverloadResolution` collects every candidate whose params are
+`isCompatibleWith` the args. Because `INT.isCompatibleWith(DOUBLE)` is true
+(numeric promotion), an `int` argument matches BOTH `abs(int)` and `abs(double)`,
+so the method throws `IllegalArgumentException("Ambiguous method call ...")`.
+
+**Fix (chosen approach — exact-match beats promotion):** when the compatibility
+scan yields more than one match, filter to candidates where every argument type
+**equals** the parameter type. If exactly one exact match remains, select it.
+Otherwise fall back to the existing Ambiguous throw. This is a localized change
+inside `findMethodWithOverloadResolution` (also covers the constructor/instance
+paths that share the same helper indirectly — only the static path is exercised
+by Math, but the fix is written once in the shared method).
+
+Compile-mode argument promotion (`I2D`) and the `INVOKESTATIC` emission already
+exist in `StaticMethodCallCompiler` (lines 140–145) and need no change.
+
+### Which methods get which overloads
+
+`java.lang.Math` signatures drive this. To keep both eval (exact-key) and compile
+(exact-match) modes clean:
+
+| Method | Overloads exposed | Return | Notes |
+|--------|-------------------|--------|-------|
+| `abs`   | `abs(int)`, `abs(double)` | int / double | Both meaningful; delegates to `java.lang.Math.abs`. |
+| `min`   | `min(int,int)`, `min(double,double)` | int / double | Delegates to `java.lang.Math.min`. |
+| `max`   | `max(int,int)`, `max(double,double)` | int / double | Delegates to `java.lang.Math.max`. |
+| `sqrt`  | `sqrt(double)` | double | Naturally double; int arg auto-promotes via I2D (compile) / widening (eval). |
+| `pow`   | `pow(double,double)` | double | Naturally double; int args promote. |
+| `floor` | `floor(double)` | double | Naturally double. |
+| `ceil`  | `ceil(double)` | double | Naturally double. |
+
+Rationale: `abs`/`min`/`max` are meaningful and commonly wanted on ints, so both
+typed overloads are provided (the resolver fix makes them unambiguous). `sqrt`,
+`pow`, `floor`, `ceil` are inherently double-valued, so a single `double` overload
+suffices — an int argument promotes cleanly in both modes (eval:
+`FunCallEvaluator.applyWideningConversions` / static path builds `#DOUBLE` key only
+if... see Risk R3; compile: `I2D`).
+
+### Eval-mode exact-key caveat (Risk R3)
+
+`StaticMethodCallEvaluator` builds the lookup key from the **actual argument
+types** (`Math.sqrt#INT` for `Math.sqrt(4)`), but only `Math.sqrt#DOUBLE` is
+registered. This is a genuine gap for the double-only methods when called with an
+int literal. The plan resolves this in Phase 1 by confirming the eval static-call
+path's behavior and, if it does not already widen, providing the int overloads too
+OR adding widening to the static-call key generation. This must be verified with a
+test before finalizing the overload table above.
+
+## Implementation Phases
+
+### Phase 1: Fix + verify overload resolution (foundation)
+
+- [ ] Add exact-match-beats-promotion logic to
+      `ExternalClassType.findMethodWithOverloadResolution`
+- [ ] Unit test: two overloads `foo(int)`/`foo(double)`, assert `foo` with INT arg
+      resolves to the int overload (not Ambiguous), DOUBLE arg → double overload
+- [ ] Unit test: genuine ambiguity (two ANY-param overloads) still throws
+- [ ] **Verify eval-mode `Math.sqrt(4)`** (int→double-only method) behavior via a
+      throwaway test; decide int-overload vs widening based on result (Risk R3)
+
+### Phase 2: Implement `Math` class
+
+- [ ] Create `com.elminster.jcp.module.base.math.Math` with private ctor and the
+      static methods per the overload table
+- [ ] Javadoc mirroring `Convert`'s style (document the single-name/typed-overload
+      design and the resolver dependency)
+- [ ] Register `Math.class` in `BaseModuleRegister.classToRegister()`
+
+### Phase 3: Tests (both modes)
+
+- [ ] Eval test `eval/function/MathTest.java` — every method, int and double
+      arguments where applicable, plus edge cases (negative abs, `sqrt(0)`,
+      `pow(2,10)`, `floor(2.7)`, `ceil(2.1)`)
+- [ ] Compile test `compile/module/MathCompileTest.java` (extends
+      `AbstractCompileTest`, mirrors `ConvertCompileTest`) — same coverage, asserts
+      via inline `Assertions.assertEquals`
+- [ ] Explicit overload-dispatch test: `Math.abs(-5)` returns INT `5`,
+      `Math.abs(-5.0)` returns DOUBLE `5.0` — proves exact-match resolution
+- [ ] `mvn verify -pl core` passes JaCoCo ≥ 80% instruction & branch
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] `Math.abs/sqrt/min/max/pow/floor/ceil` callable in eval mode
+- [ ] Same callable in compile mode
+- [ ] `Math.abs(int)` returns INT; `Math.abs(double)` returns DOUBLE (no type loss)
+- [ ] `Math` registered in `BaseModuleRegister`
+- [ ] Ambiguity fix does not break any existing STD (Convert/Arrays/Assertions) test
+
+### Non-Functional Requirements
+
+- [ ] Coverage ≥ 80% instruction and branch on core (JaCoCo)
+- [ ] No new dependencies (delegates to `java.lang.Math`)
+- [ ] Feature branch `feat/43-math-std-api`; PR to master (never commit to master)
+
+## Dependencies
+
+- Compile-mode resolver fix (Phase 1) unblocks the clean interface — must land first
+- Existing `AbstractCompileTest`, `StaticMethodCallExpression`, `Literal` helpers
+- No dependency on IO (#45); can proceed independently
+
+## Known Learnings Applied
+
+Searched `docs/solutions/` — the three existing docs are struct-type specific
+(compile-context registration, NoClassDefFound) and not directly applicable to
+`java.lang.Math` delegation. The transferable lesson — **a type/method must be
+registered in the compile context before it can be resolved** — is already
+satisfied by adding `Math.class` to `BaseModuleRegister` (Phase 2), which both
+modes consume.
+
+- `docs/solutions/logic-errors/struct-type-not-registered-in-compile-context.md`
+  — reinforces that registration in `BaseModuleRegister` is the single required
+  wiring step for compile-mode resolution.
+
+Additional project learning applied (from memory): the *Ambiguous module function*
+gotcha on numeric overloads is exactly what Phase 1 fixes; `Convert` only uses
+distinct names (`intToString`/`doubleToString`) to dodge it, and this plan does
+NOT repeat that workaround for `Math`.
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| R1: Resolver fix changes behavior for other STD classes (Arrays/Convert) that rely on current matching | M | H | Fix only narrows >1-match cases to prefer exact; run full existing STD test suite in Phase 1 before proceeding |
+| R2: `min(int,int)`/`min(double,double)` still ambiguous for mixed args e.g. `min(1, 2.0)` | L | M | Mixed args promote to `(double,double)` via I2D; no int-int candidate matches a double arg, so only one candidate — no ambiguity. Add a mixed-arg test |
+| R3: Eval `Math.sqrt(4)` builds key `sqrt#INT` but only `sqrt#DOUBLE` registered → not found | M | M | Verified in Phase 1; resolve by adding int overloads for double-only methods OR widening in the eval static-call key path. Blocks finalizing overload table |
+| R4: `pow`/`sqrt` return DOUBLE surprises users expecting int from int args | L | L | Documented in Javadoc; matches Java/most languages |
+| R5: Coverage dip from untested overload branches | L | M | Phase 3 tests every overload with both int and double literals |
+
+## Next Steps
+
+Run `/gw-work` to begin implementation on branch `feat/43-math-std-api`,
+starting with Phase 1 (resolver fix + eval-mode verification).


### PR DESCRIPTION
Closes #43

## Summary

Implements `Math` as a base-module STD class exposing seven numeric operations — `abs`, `sqrt`, `min`, `max`, `pow`, `floor`, `ceil` — callable from DSL code as `Math.abs(x)` (or `base::Math.abs(x)`) in **both eval and compile modes**, delegating to `java.lang.Math`.

The caller writes one clean name; typed Java overloads live underneath and dispatch selects the exact-type implementation (C `<tgmath.h>` semantics):
- `Math.abs(-5)` → INT `5`; `Math.abs(-5.0)` → DOUBLE `5.0` (no type loss)
- `sqrt`/`pow`/`floor`/`ceil` accept int args (widen to double)
- `Math.min(1, 2.0)` resolves unambiguously to the `(double,double)` overload

## Changes

- **Symmetric overload-resolution fix** — added a shared exact-match narrowing step (`DataType.allExactMatch` / `isExactMatch`) used by both resolvers:
  - `ExternalClassType.findMethodWithOverloadResolution` (compile mode)
  - `FunCallEvaluator` candidate selection (eval mode)

  When >1 candidate is compatible, prefer an exact-type match; fall back to the existing ambiguity error when zero or multiple exact matches remain. This retires the project-wide numeric-overload gotcha.
- **`com.elminster.jcp.module.base.math.Math`** — private ctor, 7 methods per overload table, Javadoc in `Convert` style.
- **Registered** `Math.class` in `BaseModuleRegister.classToRegister()`.
- Renamed two test-local struct types from `Math` to `Calc` to avoid colliding with the newly-registered STD class.

## Testing

- [x] `MathTest` (eval) — 11 tests, every method, int + double args, edge cases, mixed-arg promotion
- [x] `MathCompileTest` (compile) — 11 tests, mirrored coverage via inline `Assertions.assertEquals`
- [x] Resolver unit tests: exact-match preferred over widening (both modes); genuine ambiguity (no exact match) still throws
- [x] Full core suite green: **1210 tests, 0 failures**
- [x] JaCoCo: **88.5% instruction / 82.18% branch** (gate is 80%/80%)

## Checklist

- [x] Code follows project conventions (mirrors existing `Convert` STD pattern)
- [x] Tests added for new functionality (both modes)
- [x] Documentation updated (Javadoc documents the single-name/typed-overload design)