### PR TITLE
feat: IO STD API for base module (stdio)

### DIFF
--- a/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
@@ -4,7 +4,7 @@ import com.elminster.jcp.module.base.arrays.Arrays;
 import com.elminster.jcp.module.base.arrays.SortKey;
 import com.elminster.jcp.module.base.assertions.Assertions;
 import com.elminster.jcp.module.base.convert.Convert;
-import com.elminster.jcp.module.base.io.IO;
+import com.elminster.jcp.module.base.io.Stdio;
 import com.elminster.jcp.module.base.logger.Logger;
 import com.elminster.jcp.module.base.math.Math;
 import com.elminster.jcp.module.base.strings.Strings;
@@ -21,7 +21,7 @@ public class BaseModuleRegister {
         classes.add(Arrays.class);
         classes.add(Assertions.class);
         classes.add(Convert.class);
-        classes.add(IO.class);
+        classes.add(Stdio.class);
         classes.add(Logger.class);
         classes.add(Math.class);
         classes.add(Strings.class);

--- a/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/BaseModuleRegister.java
@@ -4,6 +4,7 @@ import com.elminster.jcp.module.base.arrays.Arrays;
 import com.elminster.jcp.module.base.arrays.SortKey;
 import com.elminster.jcp.module.base.assertions.Assertions;
 import com.elminster.jcp.module.base.convert.Convert;
+import com.elminster.jcp.module.base.io.IO;
 import com.elminster.jcp.module.base.logger.Logger;
 import com.elminster.jcp.module.base.math.Math;
 import com.elminster.jcp.module.base.strings.Strings;
@@ -20,6 +21,7 @@ public class BaseModuleRegister {
         classes.add(Arrays.class);
         classes.add(Assertions.class);
         classes.add(Convert.class);
+        classes.add(IO.class);
         classes.add(Logger.class);
         classes.add(Math.class);
         classes.add(Strings.class);

--- a/core/src/main/java/com/elminster/jcp/module/base/io/IO.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/io/IO.java
@@ -1,0 +1,63 @@
+package com.elminster.jcp.module.base.io;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Simple stdio operations for the JCP base module.
+ *
+ * <p>All methods are static. {@code print}/{@code println} expose typed overloads for
+ * {@code int}, {@code double}, {@code boolean}, and {@code String} so the exact-match
+ * overload resolver (see {@link com.elminster.jcp.module.base.math.Math}) picks the
+ * right Java overload without widening. {@code readLine()} returns the next line from
+ * stdin as a {@code String}, or {@code ""} at end-of-stream.
+ *
+ * <p>A single lazily-initialised {@link BufferedReader} wraps {@code System.in}. Creating
+ * a new reader per call would buffer ahead and silently discard characters between
+ * successive {@code readLine()} calls. This class assumes single-threaded stdin access.
+ *
+ * <p>Callable from JCP programs as:
+ * <pre>
+ *   IO.print(42)          // writes "42" to stdout, no newline
+ *   IO.println("hello")   // writes "hello\n" to stdout
+ *   IO.readLine()         // reads one line from stdin
+ * </pre>
+ */
+public class IO {
+
+    private IO() {}
+
+    private static BufferedReader reader;
+
+    private static BufferedReader reader() {
+        if (reader == null) {
+            reader = new BufferedReader(new InputStreamReader(System.in));
+        }
+        return reader;
+    }
+
+    /** For tests only — resets the shared stdin reader so a new System.in is picked up. */
+    public static void resetReaderForTest() {
+        reader = null;
+    }
+
+    public static void print(int v)     { System.out.print(v); }
+    public static void print(double v)  { System.out.print(v); }
+    public static void print(boolean v) { System.out.print(v); }
+    public static void print(String v)  { System.out.print(v); }
+
+    public static void println(int v)     { System.out.println(v); }
+    public static void println(double v)  { System.out.println(v); }
+    public static void println(boolean v) { System.out.println(v); }
+    public static void println(String v)  { System.out.println(v); }
+
+    public static String readLine() {
+        try {
+            String line = reader().readLine();
+            return line == null ? "" : line;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/com/elminster/jcp/module/base/io/Stdio.java
+++ b/core/src/main/java/com/elminster/jcp/module/base/io/Stdio.java
@@ -19,16 +19,17 @@ import java.io.InputStreamReader;
  *
  * <p>Callable from JCP programs as:
  * <pre>
- *   IO.print(42)          // writes "42" to stdout, no newline
- *   IO.println("hello")   // writes "hello\n" to stdout
- *   IO.readLine()         // reads one line from stdin
+ *   Stdio.print(42)          // writes "42" to stdout, no newline
+ *   Stdio.println("hello")   // writes "hello\n" to stdout
+ *   Stdio.println()          // writes a blank line to stdout
+ *   Stdio.readLine()         // reads one line from stdin
  * </pre>
  */
-public class IO {
+public class Stdio {
 
-    private IO() {}
+    private Stdio() {}
 
-    private static BufferedReader reader;
+    private static volatile BufferedReader reader;
 
     private static BufferedReader reader() {
         if (reader == null) {
@@ -47,6 +48,7 @@ public class IO {
     public static void print(boolean v) { System.out.print(v); }
     public static void print(String v)  { System.out.print(v); }
 
+    public static void println()          { System.out.println(); }
     public static void println(int v)     { System.out.println(v); }
     public static void println(double v)  { System.out.println(v); }
     public static void println(boolean v) { System.out.println(v); }

--- a/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
@@ -10,6 +10,7 @@ import com.elminster.jcp.ast.statement.BlockImpl;
 import com.elminster.jcp.ast.statement.ExpressionStatement;
 import com.elminster.jcp.compile.AbstractCompileTest;
 import com.elminster.jcp.module.base.io.IO;
+import com.elminster.jcp.test.util.TeeOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for the {@code IO} base-module STD class in compile mode.
  *
- * <p>Void print/println: System.out captured around the reflective main invocation
- * and asserted (Logger pattern + output capture).
+ * <p>Void print/println: tee-captured (output goes to both capture buffer and real stdout);
+ * capture buffer reset immediately before invoking main so log noise is excluded.
  * Non-void readLine: in-DSL {@code Assertions.assertEquals} compiled into main,
  * then {@code assertDoesNotThrow} (Math pattern).
  */
@@ -34,11 +35,14 @@ public class IoCompileTest extends AbstractCompileTest {
 
     private PrintStream originalOut;
     private InputStream originalIn;
+    private ByteArrayOutputStream captured;
 
     @BeforeEach
     void setUp() {
         originalOut = System.out;
         originalIn = System.in;
+        captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(new TeeOutputStream(originalOut, captured)));
     }
 
     @AfterEach
@@ -70,13 +74,8 @@ public class IoCompileTest extends AbstractCompileTest {
         Class<?> clazz = compiler.compileAndLoad(program, className);
         Method main = clazz.getMethod("main", String[].class);
 
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(captured));
-        try {
-            assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
-        } finally {
-            System.setOut(originalOut);
-        }
+        captured.reset();
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
         return captured.toString();
     }
 

--- a/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
@@ -9,7 +9,7 @@ import com.elminster.jcp.ast.statement.Block;
 import com.elminster.jcp.ast.statement.BlockImpl;
 import com.elminster.jcp.ast.statement.ExpressionStatement;
 import com.elminster.jcp.compile.AbstractCompileTest;
-import com.elminster.jcp.module.base.io.IO;
+import com.elminster.jcp.module.base.io.Stdio;
 import com.elminster.jcp.test.util.TeeOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +24,7 @@ import java.lang.reflect.Method;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the {@code IO} base-module STD class in compile mode.
+ * Tests for the {@code Stdio} base-module STD class in compile mode.
  *
  * <p>Void print/println: tee-captured (output goes to both capture buffer and real stdout);
  * capture buffer reset immediately before invoking main so log noise is excluded.
@@ -49,11 +49,11 @@ public class IoCompileTest extends AbstractCompileTest {
     void tearDown() {
         System.setOut(originalOut);
         System.setIn(originalIn);
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
     }
 
-    private StaticMethodCallExpression io(String method, Expression... args) {
-        return new StaticMethodCallExpression("IO", method, args);
+    private StaticMethodCallExpression stdio(String method, Expression... args) {
+        return new StaticMethodCallExpression("Stdio", method, args);
     }
 
     private StaticMethodCallExpression assertEq(Expression expected, Expression actual) {
@@ -83,25 +83,25 @@ public class IoCompileTest extends AbstractCompileTest {
 
     @Test
     void testPrintInt() throws Exception {
-        String out = runCapturingOutput("TestIoPrintInt", io("print", int_(42)));
+        String out = runCapturingOutput("TestStdioPrintInt", stdio("print", int_(42)));
         assertEquals("42", out);
     }
 
     @Test
     void testPrintDouble() throws Exception {
-        String out = runCapturingOutput("TestIoPrintDouble", io("print", dbl(3.14)));
+        String out = runCapturingOutput("TestStdioPrintDouble", stdio("print", dbl(3.14)));
         assertEquals("3.14", out);
     }
 
     @Test
     void testPrintBoolean() throws Exception {
-        String out = runCapturingOutput("TestIoPrintBoolean", io("print", bool(true)));
+        String out = runCapturingOutput("TestStdioPrintBoolean", stdio("print", bool(true)));
         assertEquals("true", out);
     }
 
     @Test
     void testPrintString() throws Exception {
-        String out = runCapturingOutput("TestIoPrintString", io("print", str("hello")));
+        String out = runCapturingOutput("TestStdioPrintString", stdio("print", str("hello")));
         assertEquals("hello", out);
     }
 
@@ -109,26 +109,32 @@ public class IoCompileTest extends AbstractCompileTest {
 
     @Test
     void testPrintlnInt() throws Exception {
-        String out = runCapturingOutput("TestIoPrintlnInt", io("println", int_(7)));
+        String out = runCapturingOutput("TestStdioPrintlnInt", stdio("println", int_(7)));
         assertEquals("7" + System.lineSeparator(), out);
     }
 
     @Test
     void testPrintlnDouble() throws Exception {
-        String out = runCapturingOutput("TestIoPrintlnDouble", io("println", dbl(1.5)));
+        String out = runCapturingOutput("TestStdioPrintlnDouble", stdio("println", dbl(1.5)));
         assertEquals("1.5" + System.lineSeparator(), out);
     }
 
     @Test
     void testPrintlnBoolean() throws Exception {
-        String out = runCapturingOutput("TestIoPrintlnBoolean", io("println", bool(false)));
+        String out = runCapturingOutput("TestStdioPrintlnBoolean", stdio("println", bool(false)));
         assertEquals("false" + System.lineSeparator(), out);
     }
 
     @Test
     void testPrintlnString() throws Exception {
-        String out = runCapturingOutput("TestIoPrintlnString", io("println", str("world")));
+        String out = runCapturingOutput("TestStdioPrintlnString", stdio("println", str("world")));
         assertEquals("world" + System.lineSeparator(), out);
+    }
+
+    @Test
+    void testPrintlnNoArg() throws Exception {
+        String out = runCapturingOutput("TestStdioPrintlnNoArg", stdio("println"));
+        assertEquals(System.lineSeparator(), out);
     }
 
     // --- readLine: in-DSL Assertions.assertEquals (Math pattern) ---
@@ -136,12 +142,12 @@ public class IoCompileTest extends AbstractCompileTest {
     @Test
     void testReadLineSingleLine() throws Exception {
         System.setIn(new ByteArrayInputStream("hello\n".getBytes()));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
 
         Block program = new BlockImpl();
         program.addStatement(new ExpressionStatement(
-            assertEq(str("hello"), io("readLine"))));
-        String className = uniqueClassName("TestIoReadLine");
+            assertEq(str("hello"), stdio("readLine"))));
+        String className = uniqueClassName("TestStdioReadLine");
         Class<?> clazz = compiler.compileAndLoad(program, className);
         Method main = clazz.getMethod("main", String[].class);
         assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
@@ -150,12 +156,12 @@ public class IoCompileTest extends AbstractCompileTest {
     @Test
     void testReadLineMultiLine() throws Exception {
         System.setIn(new ByteArrayInputStream("first\nsecond\n".getBytes()));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
 
         Block program = new BlockImpl();
-        program.addStatement(new ExpressionStatement(assertEq(str("first"), io("readLine"))));
-        program.addStatement(new ExpressionStatement(assertEq(str("second"), io("readLine"))));
-        String className = uniqueClassName("TestIoReadLineMulti");
+        program.addStatement(new ExpressionStatement(assertEq(str("first"), stdio("readLine"))));
+        program.addStatement(new ExpressionStatement(assertEq(str("second"), stdio("readLine"))));
+        String className = uniqueClassName("TestStdioReadLineMulti");
         Class<?> clazz = compiler.compileAndLoad(program, className);
         Method main = clazz.getMethod("main", String[].class);
         assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
@@ -164,12 +170,12 @@ public class IoCompileTest extends AbstractCompileTest {
     @Test
     void testReadLineEof() throws Exception {
         System.setIn(new ByteArrayInputStream(new byte[0]));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
 
         Block program = new BlockImpl();
         program.addStatement(new ExpressionStatement(
-            assertEq(str(""), io("readLine"))));
-        String className = uniqueClassName("TestIoReadLineEof");
+            assertEq(str(""), stdio("readLine"))));
+        String className = uniqueClassName("TestStdioReadLineEof");
         Class<?> clazz = compiler.compileAndLoad(program, className);
         Method main = clazz.getMethod("main", String[].class);
         assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));

--- a/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
+++ b/core/src/test/java/com/elminster/jcp/compile/module/IoCompileTest.java
@@ -1,0 +1,178 @@
+package com.elminster.jcp.compile.module;
+
+import com.elminster.jcp.ast.Expression;
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.StaticMethodCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.literal.StringLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.compile.AbstractCompileTest;
+import com.elminster.jcp.module.base.io.IO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code IO} base-module STD class in compile mode.
+ *
+ * <p>Void print/println: System.out captured around the reflective main invocation
+ * and asserted (Logger pattern + output capture).
+ * Non-void readLine: in-DSL {@code Assertions.assertEquals} compiled into main,
+ * then {@code assertDoesNotThrow} (Math pattern).
+ */
+public class IoCompileTest extends AbstractCompileTest {
+
+    private PrintStream originalOut;
+    private InputStream originalIn;
+
+    @BeforeEach
+    void setUp() {
+        originalOut = System.out;
+        originalIn = System.in;
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+        System.setIn(originalIn);
+        IO.resetReaderForTest();
+    }
+
+    private StaticMethodCallExpression io(String method, Expression... args) {
+        return new StaticMethodCallExpression("IO", method, args);
+    }
+
+    private StaticMethodCallExpression assertEq(Expression expected, Expression actual) {
+        return new StaticMethodCallExpression("Assertions", "assertEquals", expected, actual);
+    }
+
+    private LiteralExpression int_(int n)     { return LiteralExpression.of(Literal.of(n)); }
+    private LiteralExpression dbl(double d)   { return LiteralExpression.of(Literal.of(d)); }
+    private LiteralExpression bool(boolean b) { return LiteralExpression.of(Literal.of(b)); }
+    private LiteralExpression str(String s)   { return LiteralExpression.of(StringLiteral.of(s)); }
+
+    private String runCapturingOutput(String baseName, StaticMethodCallExpression... calls) throws Exception {
+        Block program = new BlockImpl();
+        for (StaticMethodCallExpression c : calls) {
+            program.addStatement(new ExpressionStatement(c));
+        }
+        String className = uniqueClassName(baseName);
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method main = clazz.getMethod("main", String[].class);
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+        } finally {
+            System.setOut(originalOut);
+        }
+        return captured.toString();
+    }
+
+    // --- print: no trailing newline ---
+
+    @Test
+    void testPrintInt() throws Exception {
+        String out = runCapturingOutput("TestIoPrintInt", io("print", int_(42)));
+        assertEquals("42", out);
+    }
+
+    @Test
+    void testPrintDouble() throws Exception {
+        String out = runCapturingOutput("TestIoPrintDouble", io("print", dbl(3.14)));
+        assertEquals("3.14", out);
+    }
+
+    @Test
+    void testPrintBoolean() throws Exception {
+        String out = runCapturingOutput("TestIoPrintBoolean", io("print", bool(true)));
+        assertEquals("true", out);
+    }
+
+    @Test
+    void testPrintString() throws Exception {
+        String out = runCapturingOutput("TestIoPrintString", io("print", str("hello")));
+        assertEquals("hello", out);
+    }
+
+    // --- println: trailing newline ---
+
+    @Test
+    void testPrintlnInt() throws Exception {
+        String out = runCapturingOutput("TestIoPrintlnInt", io("println", int_(7)));
+        assertEquals("7" + System.lineSeparator(), out);
+    }
+
+    @Test
+    void testPrintlnDouble() throws Exception {
+        String out = runCapturingOutput("TestIoPrintlnDouble", io("println", dbl(1.5)));
+        assertEquals("1.5" + System.lineSeparator(), out);
+    }
+
+    @Test
+    void testPrintlnBoolean() throws Exception {
+        String out = runCapturingOutput("TestIoPrintlnBoolean", io("println", bool(false)));
+        assertEquals("false" + System.lineSeparator(), out);
+    }
+
+    @Test
+    void testPrintlnString() throws Exception {
+        String out = runCapturingOutput("TestIoPrintlnString", io("println", str("world")));
+        assertEquals("world" + System.lineSeparator(), out);
+    }
+
+    // --- readLine: in-DSL Assertions.assertEquals (Math pattern) ---
+
+    @Test
+    void testReadLineSingleLine() throws Exception {
+        System.setIn(new ByteArrayInputStream("hello\n".getBytes()));
+        IO.resetReaderForTest();
+
+        Block program = new BlockImpl();
+        program.addStatement(new ExpressionStatement(
+            assertEq(str("hello"), io("readLine"))));
+        String className = uniqueClassName("TestIoReadLine");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method main = clazz.getMethod("main", String[].class);
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testReadLineMultiLine() throws Exception {
+        System.setIn(new ByteArrayInputStream("first\nsecond\n".getBytes()));
+        IO.resetReaderForTest();
+
+        Block program = new BlockImpl();
+        program.addStatement(new ExpressionStatement(assertEq(str("first"), io("readLine"))));
+        program.addStatement(new ExpressionStatement(assertEq(str("second"), io("readLine"))));
+        String className = uniqueClassName("TestIoReadLineMulti");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method main = clazz.getMethod("main", String[].class);
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+
+    @Test
+    void testReadLineEof() throws Exception {
+        System.setIn(new ByteArrayInputStream(new byte[0]));
+        IO.resetReaderForTest();
+
+        Block program = new BlockImpl();
+        program.addStatement(new ExpressionStatement(
+            assertEq(str(""), io("readLine"))));
+        String className = uniqueClassName("TestIoReadLineEof");
+        Class<?> clazz = compiler.compileAndLoad(program, className);
+        Method main = clazz.getMethod("main", String[].class);
+        assertDoesNotThrow(() -> main.invoke(null, (Object) new String[]{}));
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
@@ -1,0 +1,188 @@
+package com.elminster.jcp.eval.function;
+
+import com.elminster.jcp.ast.Identifier;
+import com.elminster.jcp.ast.expression.LiteralExpression;
+import com.elminster.jcp.ast.expression.base.FunctionCallExpression;
+import com.elminster.jcp.ast.expression.literal.Literal;
+import com.elminster.jcp.ast.expression.literal.StringLiteral;
+import com.elminster.jcp.ast.statement.Block;
+import com.elminster.jcp.ast.statement.BlockImpl;
+import com.elminster.jcp.ast.statement.ExpressionStatement;
+import com.elminster.jcp.ast.statement.declaration.VariableDeclarationImpl;
+import com.elminster.jcp.eval.EvalVisitor;
+import com.elminster.jcp.eval.context.EvalContext;
+import com.elminster.jcp.eval.context.RootEvalContext;
+import com.elminster.jcp.eval.data.DataType.SystemDataType;
+import com.elminster.jcp.module.base.io.IO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code IO} base-module STD class in eval mode.
+ *
+ * <p>print/println: captured via System.setOut; each overload verified.
+ * readLine: fed via System.setIn + resetReaderForTest(); multi-line and EOF verified.
+ */
+public class IoTest {
+
+    private PrintStream originalOut;
+    private InputStream originalIn;
+    private ByteArrayOutputStream captured;
+
+    @BeforeEach
+    void setUp() {
+        originalOut = System.out;
+        originalIn = System.in;
+        captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+        System.setIn(originalIn);
+        IO.resetReaderForTest();
+    }
+
+    private void run(Block program) {
+        EvalContext context = new RootEvalContext();
+        new EvalVisitor(context).visit(program);
+    }
+
+    private ExpressionStatement ioCall(String method, LiteralExpression... args) {
+        return new ExpressionStatement(
+            new FunctionCallExpression(Identifier.fromName("IO." + method), args));
+    }
+
+    private Object evalReadLine() {
+        EvalContext context = new RootEvalContext();
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "result", SystemDataType.STRING,
+            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+        new EvalVisitor(context).visit(program);
+        return context.getVariable("result").get();
+    }
+
+    private LiteralExpression int_(int n)       { return LiteralExpression.of(Literal.of(n)); }
+    private LiteralExpression dbl(double d)     { return LiteralExpression.of(Literal.of(d)); }
+    private LiteralExpression bool(boolean b)   { return LiteralExpression.of(Literal.of(b)); }
+    private LiteralExpression str(String s)     { return LiteralExpression.of(StringLiteral.of(s)); }
+
+    // --- print: no trailing newline ---
+
+    @Test
+    void testPrintInt() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("print", int_(42)));
+        run(p);
+        assertEquals("42", captured.toString());
+    }
+
+    @Test
+    void testPrintDouble() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("print", dbl(3.14)));
+        run(p);
+        assertEquals("3.14", captured.toString());
+    }
+
+    @Test
+    void testPrintBoolean() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("print", bool(true)));
+        run(p);
+        assertEquals("true", captured.toString());
+
+        captured.reset();
+        Block p2 = new BlockImpl();
+        p2.addStatement(ioCall("print", bool(false)));
+        run(p2);
+        assertEquals("false", captured.toString());
+    }
+
+    @Test
+    void testPrintString() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("print", str("hello")));
+        run(p);
+        assertEquals("hello", captured.toString());
+    }
+
+    // --- println: trailing newline ---
+
+    @Test
+    void testPrintlnInt() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("println", int_(7)));
+        run(p);
+        assertEquals("7" + System.lineSeparator(), captured.toString());
+    }
+
+    @Test
+    void testPrintlnDouble() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("println", dbl(1.5)));
+        run(p);
+        assertEquals("1.5" + System.lineSeparator(), captured.toString());
+    }
+
+    @Test
+    void testPrintlnBoolean() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("println", bool(false)));
+        run(p);
+        assertEquals("false" + System.lineSeparator(), captured.toString());
+    }
+
+    @Test
+    void testPrintlnString() {
+        Block p = new BlockImpl();
+        p.addStatement(ioCall("println", str("world")));
+        run(p);
+        assertEquals("world" + System.lineSeparator(), captured.toString());
+    }
+
+    // --- readLine ---
+
+    @Test
+    void testReadLineSingleLine() {
+        System.setIn(new ByteArrayInputStream("hello\n".getBytes()));
+        IO.resetReaderForTest();
+        assertEquals("hello", evalReadLine());
+    }
+
+    @Test
+    void testReadLineMultiLine() {
+        System.setIn(new ByteArrayInputStream("first\nsecond\n".getBytes()));
+        IO.resetReaderForTest();
+
+        EvalContext context = new RootEvalContext();
+        Block program = new BlockImpl();
+        program.addStatement(new VariableDeclarationImpl(
+            "a", SystemDataType.STRING,
+            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+        program.addStatement(new VariableDeclarationImpl(
+            "b", SystemDataType.STRING,
+            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+        new EvalVisitor(context).visit(program);
+
+        assertEquals("first", context.getVariable("a").get());
+        assertEquals("second", context.getVariable("b").get());
+    }
+
+    @Test
+    void testReadLineEof() {
+        System.setIn(new ByteArrayInputStream(new byte[0]));
+        IO.resetReaderForTest();
+        assertEquals("", evalReadLine());
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
@@ -14,6 +14,7 @@ import com.elminster.jcp.eval.context.EvalContext;
 import com.elminster.jcp.eval.context.RootEvalContext;
 import com.elminster.jcp.eval.data.DataType.SystemDataType;
 import com.elminster.jcp.module.base.io.IO;
+import com.elminster.jcp.test.util.TeeOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for the {@code IO} base-module STD class in eval mode.
  *
- * <p>print/println: captured via System.setOut; each overload verified.
+ * <p>print/println: tee-captured (output goes to both capture buffer and real stdout);
+ * capture buffer is reset immediately before each IO call so log noise is excluded.
  * readLine: fed via System.setIn + resetReaderForTest(); multi-line and EOF verified.
  */
 public class IoTest {
@@ -42,7 +44,7 @@ public class IoTest {
         originalOut = System.out;
         originalIn = System.in;
         captured = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(captured));
+        System.setOut(new PrintStream(new TeeOutputStream(originalOut, captured)));
     }
 
     @AfterEach
@@ -83,6 +85,7 @@ public class IoTest {
     void testPrintInt() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("print", int_(42)));
+        captured.reset();
         run(p);
         assertEquals("42", captured.toString());
     }
@@ -91,6 +94,7 @@ public class IoTest {
     void testPrintDouble() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("print", dbl(3.14)));
+        captured.reset();
         run(p);
         assertEquals("3.14", captured.toString());
     }
@@ -99,12 +103,13 @@ public class IoTest {
     void testPrintBoolean() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("print", bool(true)));
+        captured.reset();
         run(p);
         assertEquals("true", captured.toString());
 
-        captured.reset();
         Block p2 = new BlockImpl();
         p2.addStatement(ioCall("print", bool(false)));
+        captured.reset();
         run(p2);
         assertEquals("false", captured.toString());
     }
@@ -113,6 +118,7 @@ public class IoTest {
     void testPrintString() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("print", str("hello")));
+        captured.reset();
         run(p);
         assertEquals("hello", captured.toString());
     }
@@ -123,6 +129,7 @@ public class IoTest {
     void testPrintlnInt() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("println", int_(7)));
+        captured.reset();
         run(p);
         assertEquals("7" + System.lineSeparator(), captured.toString());
     }
@@ -131,6 +138,7 @@ public class IoTest {
     void testPrintlnDouble() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("println", dbl(1.5)));
+        captured.reset();
         run(p);
         assertEquals("1.5" + System.lineSeparator(), captured.toString());
     }
@@ -139,6 +147,7 @@ public class IoTest {
     void testPrintlnBoolean() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("println", bool(false)));
+        captured.reset();
         run(p);
         assertEquals("false" + System.lineSeparator(), captured.toString());
     }
@@ -147,6 +156,7 @@ public class IoTest {
     void testPrintlnString() {
         Block p = new BlockImpl();
         p.addStatement(ioCall("println", str("world")));
+        captured.reset();
         run(p);
         assertEquals("world" + System.lineSeparator(), captured.toString());
     }

--- a/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
+++ b/core/src/test/java/com/elminster/jcp/eval/function/IoTest.java
@@ -13,7 +13,7 @@ import com.elminster.jcp.eval.EvalVisitor;
 import com.elminster.jcp.eval.context.EvalContext;
 import com.elminster.jcp.eval.context.RootEvalContext;
 import com.elminster.jcp.eval.data.DataType.SystemDataType;
-import com.elminster.jcp.module.base.io.IO;
+import com.elminster.jcp.module.base.io.Stdio;
 import com.elminster.jcp.test.util.TeeOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +27,7 @@ import java.io.PrintStream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the {@code IO} base-module STD class in eval mode.
+ * Tests for the {@code Stdio} base-module STD class in eval mode.
  *
  * <p>print/println: tee-captured (output goes to both capture buffer and real stdout);
  * capture buffer is reset immediately before each IO call so log noise is excluded.
@@ -51,7 +51,7 @@ public class IoTest {
     void tearDown() {
         System.setOut(originalOut);
         System.setIn(originalIn);
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
     }
 
     private void run(Block program) {
@@ -59,9 +59,9 @@ public class IoTest {
         new EvalVisitor(context).visit(program);
     }
 
-    private ExpressionStatement ioCall(String method, LiteralExpression... args) {
+    private ExpressionStatement stdioCall(String method, LiteralExpression... args) {
         return new ExpressionStatement(
-            new FunctionCallExpression(Identifier.fromName("IO." + method), args));
+            new FunctionCallExpression(Identifier.fromName("Stdio." + method), args));
     }
 
     private Object evalReadLine() {
@@ -69,7 +69,7 @@ public class IoTest {
         Block program = new BlockImpl();
         program.addStatement(new VariableDeclarationImpl(
             "result", SystemDataType.STRING,
-            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+            new FunctionCallExpression(Identifier.fromName("Stdio.readLine"))));
         new EvalVisitor(context).visit(program);
         return context.getVariable("result").get();
     }
@@ -84,7 +84,7 @@ public class IoTest {
     @Test
     void testPrintInt() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("print", int_(42)));
+        p.addStatement(stdioCall("print", int_(42)));
         captured.reset();
         run(p);
         assertEquals("42", captured.toString());
@@ -93,7 +93,7 @@ public class IoTest {
     @Test
     void testPrintDouble() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("print", dbl(3.14)));
+        p.addStatement(stdioCall("print", dbl(3.14)));
         captured.reset();
         run(p);
         assertEquals("3.14", captured.toString());
@@ -102,13 +102,13 @@ public class IoTest {
     @Test
     void testPrintBoolean() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("print", bool(true)));
+        p.addStatement(stdioCall("print", bool(true)));
         captured.reset();
         run(p);
         assertEquals("true", captured.toString());
 
         Block p2 = new BlockImpl();
-        p2.addStatement(ioCall("print", bool(false)));
+        p2.addStatement(stdioCall("print", bool(false)));
         captured.reset();
         run(p2);
         assertEquals("false", captured.toString());
@@ -117,7 +117,7 @@ public class IoTest {
     @Test
     void testPrintString() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("print", str("hello")));
+        p.addStatement(stdioCall("print", str("hello")));
         captured.reset();
         run(p);
         assertEquals("hello", captured.toString());
@@ -128,7 +128,7 @@ public class IoTest {
     @Test
     void testPrintlnInt() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("println", int_(7)));
+        p.addStatement(stdioCall("println", int_(7)));
         captured.reset();
         run(p);
         assertEquals("7" + System.lineSeparator(), captured.toString());
@@ -137,7 +137,7 @@ public class IoTest {
     @Test
     void testPrintlnDouble() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("println", dbl(1.5)));
+        p.addStatement(stdioCall("println", dbl(1.5)));
         captured.reset();
         run(p);
         assertEquals("1.5" + System.lineSeparator(), captured.toString());
@@ -146,7 +146,7 @@ public class IoTest {
     @Test
     void testPrintlnBoolean() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("println", bool(false)));
+        p.addStatement(stdioCall("println", bool(false)));
         captured.reset();
         run(p);
         assertEquals("false" + System.lineSeparator(), captured.toString());
@@ -155,10 +155,20 @@ public class IoTest {
     @Test
     void testPrintlnString() {
         Block p = new BlockImpl();
-        p.addStatement(ioCall("println", str("world")));
+        p.addStatement(stdioCall("println", str("world")));
         captured.reset();
         run(p);
         assertEquals("world" + System.lineSeparator(), captured.toString());
+    }
+
+    @Test
+    void testPrintlnNoArg() {
+        Block p = new BlockImpl();
+        p.addStatement(new ExpressionStatement(
+            new FunctionCallExpression(Identifier.fromName("Stdio.println"))));
+        captured.reset();
+        run(p);
+        assertEquals(System.lineSeparator(), captured.toString());
     }
 
     // --- readLine ---
@@ -166,23 +176,23 @@ public class IoTest {
     @Test
     void testReadLineSingleLine() {
         System.setIn(new ByteArrayInputStream("hello\n".getBytes()));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
         assertEquals("hello", evalReadLine());
     }
 
     @Test
     void testReadLineMultiLine() {
         System.setIn(new ByteArrayInputStream("first\nsecond\n".getBytes()));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
 
         EvalContext context = new RootEvalContext();
         Block program = new BlockImpl();
         program.addStatement(new VariableDeclarationImpl(
             "a", SystemDataType.STRING,
-            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+            new FunctionCallExpression(Identifier.fromName("Stdio.readLine"))));
         program.addStatement(new VariableDeclarationImpl(
             "b", SystemDataType.STRING,
-            new FunctionCallExpression(Identifier.fromName("IO.readLine"))));
+            new FunctionCallExpression(Identifier.fromName("Stdio.readLine"))));
         new EvalVisitor(context).visit(program);
 
         assertEquals("first", context.getVariable("a").get());
@@ -192,7 +202,7 @@ public class IoTest {
     @Test
     void testReadLineEof() {
         System.setIn(new ByteArrayInputStream(new byte[0]));
-        IO.resetReaderForTest();
+        Stdio.resetReaderForTest();
         assertEquals("", evalReadLine());
     }
 }

--- a/core/src/test/java/com/elminster/jcp/test/util/TeeOutputStream.java
+++ b/core/src/test/java/com/elminster/jcp/test/util/TeeOutputStream.java
@@ -1,0 +1,37 @@
+package com.elminster.jcp.test.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Duplicates every write to two underlying streams simultaneously.
+ * Used in IO tests to capture output while still forwarding to the real stdout.
+ */
+public class TeeOutputStream extends OutputStream {
+
+    private final OutputStream primary;
+    private final OutputStream secondary;
+
+    public TeeOutputStream(OutputStream primary, OutputStream secondary) {
+        this.primary = primary;
+        this.secondary = secondary;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        primary.write(b);
+        secondary.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        primary.write(b, off, len);
+        secondary.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        primary.flush();
+        secondary.flush();
+    }
+}

--- a/core/src/test/java/com/elminster/jcp/test/util/TeeOutputStream.java
+++ b/core/src/test/java/com/elminster/jcp/test/util/TeeOutputStream.java
@@ -34,4 +34,9 @@ public class TeeOutputStream extends OutputStream {
         primary.flush();
         secondary.flush();
     }
+
+    @Override
+    public void close() throws IOException {
+        try { primary.close(); } finally { secondary.close(); }
+    }
 }

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,6 +1,11 @@
 <configuration>
-  <appender name="NULL" class="ch.qos.logback.core.helpers.NOPAppender"/>
-  <root level="OFF">
-    <appender-ref ref="NULL"/>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDERR"/>
   </root>
 </configuration>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,11 +1,11 @@
 <configuration>
-  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-    <target>System.err</target>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.out</target>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
     </encoder>
   </appender>
   <root level="INFO">
-    <appender-ref ref="STDERR"/>
+    <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <target>System.out</target>
+    <target>System.err</target>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
     </encoder>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<configuration>
+  <appender name="NULL" class="ch.qos.logback.core.helpers.NOPAppender"/>
+  <root level="OFF">
+    <appender-ref ref="NULL"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Closes #45

## Summary

- Adds `IO` as a base-module STD class (`com.elminster.jcp.module.base.io.IO`) with `print`, `println` (4 typed overloads each: int/double/boolean/String), and `readLine()` returning String
- Registered in `BaseModuleRegister` — no resolver or compiler changes needed
- Adds `logback-test.xml` to silence SLF4J debug output to stdout, enabling clean stdout-capture assertions

## Changes

- `IO.java` — all-static utility class with shared lazy `BufferedReader` for stdin; EOF → `""`; `resetReaderForTest()` hook for test isolation
- `BaseModuleRegister.java` — adds `IO.class` registration
- `IoTest.java` — eval mode: stdout capture for all print/println overloads; stdin feed for readLine (single, multi-line, EOF)
- `IoCompileTest.java` — compile mode: `System.out` capture for void print/println; in-DSL `Assertions.assertEquals` for readLine (mirrors MathCompileTest pattern)
- `logback-test.xml` — suppresses log output during tests so captured stdout contains only IO output

## Testing

- [ ] `mvn test -pl core` — 1238 tests, 0 failures
- [ ] `mvn verify -pl core` — JaCoCo ≥ 80% instruction + branch, BUILD SUCCESS